### PR TITLE
Remove backticks from parameters

### DIFF
--- a/etl/ddl/ddl_cdm_5_3_1.sql
+++ b/etl/ddl/ddl_cdm_5_3_1.sql
@@ -6,7 +6,7 @@
 /*OMOP CDM v5.3.1 14June2018*/
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cohort_definition (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cohort_definition (
   cohort_definition_id            INT64       not null,
   cohort_definition_name          STRING      not null,
   cohort_definition_description   STRING              ,
@@ -18,7 +18,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cohort_definition (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_attribute_definition (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_attribute_definition (
   attribute_definition_id     INT64       not null,
   attribute_name              STRING      not null,
   attribute_description       STRING              ,
@@ -28,7 +28,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_attribute_definition (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cdm_source
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cdm_source
 (
   cdm_source_name                 STRING        not null ,
   cdm_source_abbreviation         STRING             ,
@@ -44,7 +44,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cdm_source
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_metadata
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_metadata
 (
   metadata_concept_id       INT64       not null ,
   metadata_type_concept_id  INT64       not null ,
@@ -59,7 +59,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_metadata
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_person
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_person
 (
   person_id                   INT64     not null ,
   gender_concept_id           INT64     not null ,
@@ -84,7 +84,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_person
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_observation_period
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_observation_period
 (
   observation_period_id             INT64   not null ,
   person_id                         INT64   not null ,
@@ -96,7 +96,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_observation_period
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_specimen
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_specimen
 (
   specimen_id                 INT64     not null ,
   person_id                   INT64     not null ,
@@ -118,7 +118,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_specimen
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_death
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_death
 (
   person_id               INT64     not null ,
   death_date              DATE      not null ,
@@ -132,7 +132,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_death
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_visit_occurrence
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_visit_occurrence
 (
   visit_occurrence_id           INT64     not null ,
   person_id                     INT64     not null ,
@@ -156,7 +156,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_visit_occurrence
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_visit_detail
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_visit_detail
 (
   visit_detail_id                    INT64     not null ,
   person_id                          INT64     not null ,
@@ -182,7 +182,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_visit_detail
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_procedure_occurrence
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_procedure_occurrence
 (
   procedure_occurrence_id     INT64     not null ,
   person_id                   INT64     not null ,
@@ -203,7 +203,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_procedure_occurrence
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_drug_exposure
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_drug_exposure
 (
   drug_exposure_id              INT64       not null ,
   person_id                     INT64       not null ,
@@ -233,7 +233,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_drug_exposure
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_device_exposure
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_device_exposure
 (
   device_exposure_id              INT64       not null ,
   person_id                       INT64       not null ,
@@ -255,7 +255,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_device_exposure
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_condition_occurrence
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_condition_occurrence
 (
   condition_occurrence_id       INT64     not null ,
   person_id                     INT64     not null ,
@@ -278,7 +278,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_condition_occurrence
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_measurement
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_measurement
 (
   measurement_id                INT64     not null ,
   person_id                     INT64     not null ,
@@ -305,7 +305,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_measurement
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_note
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_note
 (
   note_id               INT64       not null ,
   person_id             INT64       not null ,
@@ -326,7 +326,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_note
 
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_note_nlp
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_note_nlp
 (
   note_nlp_id                 INT64                ,
   note_id                     INT64                ,
@@ -347,7 +347,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_note_nlp
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_observation
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_observation
 (
   observation_id                INT64     not null ,
   person_id                     INT64     not null ,
@@ -371,7 +371,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_observation
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_fact_relationship
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_fact_relationship
 (
   domain_concept_id_1     INT64     not null ,
   fact_id_1               INT64     not null ,
@@ -382,7 +382,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_fact_relationship
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_location
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_location
 (
   location_id           INT64     not null ,
   address_1             STRING             ,
@@ -396,7 +396,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_location
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_care_site
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_care_site
 (
   care_site_id                  INT64       not null ,
   care_site_name                STRING               ,
@@ -408,7 +408,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_care_site
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_provider
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_provider
 (
   provider_id                 INT64       not null ,
   provider_name               STRING               ,
@@ -428,7 +428,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_provider
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_payer_plan_period
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_payer_plan_period
 (
   payer_plan_period_id          INT64     not null ,
   person_id                     INT64     not null ,
@@ -451,7 +451,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_payer_plan_period
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cost
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cost
 (
   cost_id                   INT64     not null ,
   cost_event_id             INT64     not null ,
@@ -480,7 +480,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cost
 
 
 --HINT DISTRIBUTE_ON_KEY(subject_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cohort
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cohort
 (
   cohort_definition_id  INT64   not null ,
   subject_id            INT64   not null ,
@@ -491,7 +491,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cohort
 
 
 --HINT DISTRIBUTE_ON_KEY(subject_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cohort_attribute
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cohort_attribute
 (
   cohort_definition_id    INT64     not null ,
   subject_id              INT64     not null ,
@@ -505,7 +505,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cohort_attribute
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_drug_era
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_drug_era
 (
   drug_era_id         INT64     not null ,
   person_id           INT64     not null ,
@@ -519,7 +519,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_drug_era
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_dose_era
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_dose_era
 (
   dose_era_id           INT64     not null ,
   person_id             INT64     not null ,
@@ -533,7 +533,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_dose_era
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_condition_era
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_condition_era
 (
   condition_era_id            INT64     not null ,
   person_id                   INT64     not null ,

--- a/etl/ddl/ddl_voc_5_3_1.sql
+++ b/etl/ddl/ddl_voc_5_3_1.sql
@@ -1,6 +1,6 @@
 /*OMOP CDM v5.3.1 14June2018*/
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept (
   concept_id          INT64       not null ,
   concept_name        STRING      not null ,
   domain_id           STRING      not null ,
@@ -15,7 +15,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_vocabulary (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_vocabulary (
   vocabulary_id         STRING      not null,
   vocabulary_name       STRING      not null,
   vocabulary_reference  STRING      not null,
@@ -25,7 +25,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_vocabulary (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_domain (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_domain (
   domain_id         STRING      not null,
   domain_name       STRING      not null,
   domain_concept_id INT64       not null
@@ -33,7 +33,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_domain (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_class (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept_class (
   concept_class_id          STRING      not null,
   concept_class_name        STRING      not null,
   concept_class_concept_id  INT64       not null
@@ -41,7 +41,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_class (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_relationship (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept_relationship (
   concept_id_1      INT64     not null,
   concept_id_2      INT64     not null,
   relationship_id   STRING    not null,
@@ -52,7 +52,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_relationship (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_relationship (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_relationship (
   relationship_id         STRING      not null,
   relationship_name       STRING      not null,
   is_hierarchical         STRING      not null,
@@ -63,7 +63,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_relationship (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_synonym (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept_synonym (
   concept_id            INT64       not null,
   concept_synonym_name  STRING      not null,
   language_concept_id   INT64       not null
@@ -71,7 +71,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_synonym (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_ancestor (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept_ancestor (
   ancestor_concept_id       INT64   not null,
   descendant_concept_id     INT64   not null,
   min_levels_of_separation  INT64   not null,
@@ -80,7 +80,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_ancestor (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_source_to_concept_map (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_source_to_concept_map (
   source_code             STRING      not null,
   source_concept_id       INT64       not null,
   source_vocabulary_id    STRING      not null,
@@ -94,7 +94,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_source_to_concept_map (
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_drug_strength (
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_drug_strength (
   drug_concept_id             INT64     not null,
   ingredient_concept_id       INT64     not null,
   amount_value                FLOAT64           ,

--- a/etl/etl/cdm_care_site.sql
+++ b/etl/etl/cdm_care_site.sql
@@ -25,14 +25,14 @@
 -- lk_trans_careunit_clean
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_trans_careunit_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_trans_careunit_clean AS
 SELECT
     src.careunit                        AS source_code,
     src.load_table_id                   AS load_table_id,
     0                                   AS load_row_id,
     MIN(src.trace_id)                   AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.src_transfers src
+    @etl_project.@etl_dataset.src_transfers src
 WHERE
     src.careunit IS NOT NULL
 GROUP BY
@@ -46,7 +46,7 @@ GROUP BY
 -- cdm_care_site
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_care_site
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_care_site
 (
     care_site_id                  INT64       not null ,
     care_site_name                STRING               ,
@@ -62,7 +62,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_care_site
 )
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_care_site
+INSERT INTO @etl_project.@etl_dataset.cdm_care_site
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())   AS care_site_id,
     src.source_code                     AS care_site_name,
@@ -75,17 +75,17 @@ SELECT
     src.load_row_id             AS load_row_id,
     src.trace_id                AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.lk_trans_careunit_clean src
+    @etl_project.@etl_dataset.lk_trans_careunit_clean src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON  vc.concept_code = src.source_code
         AND vc.vocabulary_id = 'mimiciv_cs_place_of_service' -- gcpt_care_site
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL

--- a/etl/etl/cdm_cdm_source.sql
+++ b/etl/etl/cdm_cdm_source.sql
@@ -20,7 +20,7 @@
 -- Add second row for Waveform POC?
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cdm_source
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cdm_source
 (
     cdm_source_name                 STRING        not null ,
     cdm_source_abbreviation         STRING             ,
@@ -40,7 +40,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_cdm_source
 )
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_cdm_source
+INSERT INTO @etl_project.@etl_dataset.cdm_cdm_source
 SELECT
     'MIMIC IV'                              AS cdm_source_name,
     'mimiciv'                               AS cdm_source_abbreviation,
@@ -62,7 +62,7 @@ SELECT
     ))                                  AS trace_id
 
 FROM 
-    `@etl_project`.@etl_dataset.voc_vocabulary v
+    @etl_project.@etl_dataset.voc_vocabulary v
 WHERE
     v.vocabulary_id = 'None'
 ;

--- a/etl/etl/cdm_condition_occurrence.sql
+++ b/etl/etl/cdm_condition_occurrence.sql
@@ -29,7 +29,7 @@
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_condition_occurrence
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_condition_occurrence
 (
     condition_occurrence_id       INT64     not null ,
     person_id                     INT64     not null ,
@@ -60,7 +60,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_condition_occurrence
 -- diagnoses
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_condition_occurrence
+INSERT INTO @etl_project.@etl_dataset.cdm_condition_occurrence
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())       AS condition_occurrence_id,
     per.person_id                           AS person_id,
@@ -84,12 +84,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_diagnoses_icd_mapped src
+    @etl_project.@etl_dataset.lk_diagnoses_icd_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -101,7 +101,7 @@ WHERE
 -- Chartevents.value
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_condition_occurrence
+INSERT INTO @etl_project.@etl_dataset.cdm_condition_occurrence
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())       AS condition_occurrence_id,
     per.person_id                           AS person_id,
@@ -125,12 +125,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_chartevents_condition_mapped src
+    @etl_project.@etl_dataset.lk_chartevents_condition_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -144,7 +144,7 @@ WHERE
 -- Chartevents
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_condition_occurrence
+INSERT INTO @etl_project.@etl_dataset.cdm_condition_occurrence
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())       AS condition_occurrence_id,
     per.person_id                           AS person_id,
@@ -168,12 +168,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_chartevents_mapped src
+    @etl_project.@etl_dataset.lk_chartevents_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE

--- a/etl/etl/cdm_death.sql
+++ b/etl/etl/cdm_death.sql
@@ -16,7 +16,7 @@
 -- Rule 1, admissionss
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_death_adm_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_death_adm_mapped AS
 SELECT DISTINCT
     src.subject_id, 
     FIRST_VALUE(src.deathtime) OVER(
@@ -40,7 +40,7 @@ SELECT DISTINCT
         ORDER BY src.admittime ASC
     )                                   AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.src_admissions src -- adm
+    @etl_project.@etl_dataset.src_admissions src -- adm
 WHERE 
     src.deathtime IS NOT NULL
 ;
@@ -50,7 +50,7 @@ WHERE
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_death
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_death
 (
     person_id               INT64     not null ,
     death_date              DATE      not null ,
@@ -67,7 +67,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_death
 )
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_death
+INSERT INTO @etl_project.@etl_dataset.cdm_death
 SELECT
     per.person_id       AS person_id,
     CAST(IF(
@@ -88,8 +88,8 @@ SELECT
     src.load_row_id         AS load_row_id,
     src.trace_id            AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_death_adm_mapped src
+    @etl_project.@etl_dataset.lk_death_adm_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 ;

--- a/etl/etl/cdm_device_exposure.sql
+++ b/etl/etl/cdm_device_exposure.sql
@@ -25,7 +25,7 @@
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_device_exposure
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_device_exposure
 (
     device_exposure_id              INT64       not null ,
     person_id                       INT64       not null ,
@@ -51,7 +51,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_device_exposure
 ;
 
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_device_exposure
+INSERT INTO @etl_project.@etl_dataset.cdm_device_exposure
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS device_exposure_id,
     per.person_id                               AS person_id,
@@ -76,12 +76,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_drug_mapped src
+    @etl_project.@etl_dataset.lk_drug_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -89,7 +89,7 @@ WHERE
 ;
 
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_device_exposure
+INSERT INTO @etl_project.@etl_dataset.cdm_device_exposure
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS device_exposure_id,
     per.person_id                               AS person_id,
@@ -114,12 +114,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_chartevents_mapped src
+    @etl_project.@etl_dataset.lk_chartevents_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE

--- a/etl/etl/cdm_drug_exposure.sql
+++ b/etl/etl/cdm_drug_exposure.sql
@@ -22,7 +22,7 @@
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_drug_exposure
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_drug_exposure
 (
     drug_exposure_id              INT64       not null ,
     person_id                     INT64       not null ,
@@ -55,7 +55,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_drug_exposure
 )
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_drug_exposure
+INSERT INTO @etl_project.@etl_dataset.cdm_drug_exposure
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS drug_exposure_id,
     per.person_id                               AS person_id,
@@ -86,12 +86,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_drug_mapped src
+    @etl_project.@etl_dataset.lk_drug_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE

--- a/etl/etl/cdm_fact_relationship.sql
+++ b/etl/etl/cdm_fact_relationship.sql
@@ -10,7 +10,7 @@
 -- -------------------------------------------------------------------
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_fact_relationship
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_fact_relationship
 (
     domain_concept_id_1     INT64     not null ,
     fact_id_1               INT64     not null ,
@@ -26,7 +26,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_fact_relationship
 -- specimen to test-organism
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_fact_relationship
+INSERT INTO @etl_project.@etl_dataset.cdm_fact_relationship
 SELECT
     36                      AS domain_concept_id_1, -- Specimen
     spec.specimen_id        AS fact_id_1,
@@ -35,13 +35,13 @@ SELECT
     32669                   AS relationship_concept_id, -- Specimen to Measurement   Standard
     'fact.spec.test'        AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.lk_specimen_mapped spec
+    @etl_project.@etl_dataset.lk_specimen_mapped spec
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_meas_organism_mapped org
+    @etl_project.@etl_dataset.lk_meas_organism_mapped org
         ON org.trace_id_spec = spec.trace_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_fact_relationship
+INSERT INTO @etl_project.@etl_dataset.cdm_fact_relationship
 SELECT
     21                      AS domain_concept_id_1, -- Measurement
     org.measurement_id      AS fact_id_1,
@@ -50,9 +50,9 @@ SELECT
     32668                   AS relationship_concept_id, -- Measurement to Specimen   Standard
     'fact.test.spec'        AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.lk_specimen_mapped spec
+    @etl_project.@etl_dataset.lk_specimen_mapped spec
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_meas_organism_mapped org
+    @etl_project.@etl_dataset.lk_meas_organism_mapped org
         ON org.trace_id_spec = spec.trace_id
 ;
 
@@ -60,7 +60,7 @@ INNER JOIN
 -- test-organism to antibiotic
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_fact_relationship
+INSERT INTO @etl_project.@etl_dataset.cdm_fact_relationship
 SELECT
     21                      AS domain_concept_id_1, -- Measurement
     org.measurement_id      AS fact_id_1,
@@ -69,13 +69,13 @@ SELECT
     581436                  AS relationship_concept_id, -- Parent to Child Measurement   Standard
     'fact.test.ab'          AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_organism_mapped org
+    @etl_project.@etl_dataset.lk_meas_organism_mapped org
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_meas_ab_mapped ab
+    @etl_project.@etl_dataset.lk_meas_ab_mapped ab
         ON ab.trace_id_org = org.trace_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_fact_relationship
+INSERT INTO @etl_project.@etl_dataset.cdm_fact_relationship
 SELECT
     21                      AS domain_concept_id_1, -- Measurement
     ab.measurement_id       AS fact_id_1,
@@ -84,8 +84,8 @@ SELECT
     581437                  AS relationship_concept_id, -- Child to Parent Measurement   Standard
     'fact.ab.test'          AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_organism_mapped org
+    @etl_project.@etl_dataset.lk_meas_organism_mapped org
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_meas_ab_mapped ab
+    @etl_project.@etl_dataset.lk_meas_ab_mapped ab
         ON ab.trace_id_org = org.trace_id
 ;

--- a/etl/etl/cdm_finalize_person.sql
+++ b/etl/etl/cdm_finalize_person.sql
@@ -19,21 +19,21 @@
 -- cdm_person
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.tmp_person AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.tmp_person AS
 SELECT per.*
 FROM 
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_observation_period op
+    @etl_project.@etl_dataset.cdm_observation_period op
         ON  per.person_id = op.person_id
 ;
 
-TRUNCATE TABLE `@etl_project`.@etl_dataset.cdm_person;
+TRUNCATE TABLE @etl_project.@etl_dataset.cdm_person;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_person
+INSERT INTO @etl_project.@etl_dataset.cdm_person
 SELECT per.*
 FROM
-    `@etl_project`.@etl_dataset.tmp_person per
+    @etl_project.@etl_dataset.tmp_person per
 ;
 
-DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.tmp_person;
+DROP TABLE IF EXISTS @etl_project.@etl_dataset.tmp_person;

--- a/etl/etl/cdm_location.sql
+++ b/etl/etl/cdm_location.sql
@@ -21,7 +21,7 @@
 -- cdm_location
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_location
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_location
 (
     location_id           INT64     not null ,
     address_1             STRING             ,
@@ -39,7 +39,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_location
 )
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_location
+INSERT INTO @etl_project.@etl_dataset.cdm_location
 SELECT
     1                           AS location_id,
     CAST(NULL AS STRING)        AS address_1,

--- a/etl/etl/cdm_measurement.sql
+++ b/etl/etl/cdm_measurement.sql
@@ -29,7 +29,7 @@
 
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_measurement
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_measurement
 (
     measurement_id                INT64     not null ,
     person_id                     INT64     not null ,
@@ -65,7 +65,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_measurement
 -- demo:  115,272 rows from mapped 107,209 rows. Remove duplicates
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_measurement
+INSERT INTO @etl_project.@etl_dataset.cdm_measurement
 SELECT
     src.measurement_id                      AS measurement_id,
     per.person_id                           AS person_id,
@@ -93,12 +93,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM  
-    `@etl_project`.@etl_dataset.lk_meas_labevents_mapped src -- 107,209 
+    @etl_project.@etl_dataset.lk_meas_labevents_mapped src -- 107,209 
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per -- 110,849
+    @etl_project.@etl_dataset.cdm_person per -- 110,849
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis -- 116,559
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', 
                 COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
@@ -111,7 +111,7 @@ WHERE
 -- chartevents
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_measurement
+INSERT INTO @etl_project.@etl_dataset.cdm_measurement
 SELECT
     src.measurement_id                      AS measurement_id,
     per.person_id                           AS person_id,
@@ -139,12 +139,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM  
-    `@etl_project`.@etl_dataset.lk_chartevents_mapped src
+    @etl_project.@etl_dataset.lk_chartevents_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -156,7 +156,7 @@ WHERE
 -- Microbiology - organism
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_measurement
+INSERT INTO @etl_project.@etl_dataset.cdm_measurement
 SELECT
     src.measurement_id                      AS measurement_id,
     per.person_id                           AS person_id,
@@ -184,12 +184,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM  
-    `@etl_project`.@etl_dataset.lk_meas_organism_mapped src
+    @etl_project.@etl_dataset.lk_meas_organism_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis -- 116,559
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', 
                 COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
@@ -202,7 +202,7 @@ WHERE
 -- Microbiology - antibiotics
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_measurement
+INSERT INTO @etl_project.@etl_dataset.cdm_measurement
 SELECT
     src.measurement_id                      AS measurement_id,
     per.person_id                           AS person_id,
@@ -230,12 +230,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM  
-    `@etl_project`.@etl_dataset.lk_meas_ab_mapped src
+    @etl_project.@etl_dataset.lk_meas_ab_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis -- 116,559
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', 
                 COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
@@ -249,7 +249,7 @@ WHERE
 -- wf demo poc: 1,500 rows from 1,500 rows in mapped
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_measurement
+INSERT INTO @etl_project.@etl_dataset.cdm_measurement
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())       AS measurement_id,
     per.person_id                           AS person_id,
@@ -277,12 +277,12 @@ SELECT
     src.load_row_id                         AS load_row_id,
     src.trace_id                            AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_waveform_mapped src
+    @etl_project.@etl_dataset.lk_meas_waveform_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per 
+    @etl_project.@etl_dataset.cdm_person per 
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_detail vd 
+    @etl_project.@etl_dataset.cdm_visit_detail vd 
         ON src.reference_id = vd.visit_detail_source_value
 WHERE
     src.target_domain_id = 'Measurement'

--- a/etl/etl/cdm_observation.sql
+++ b/etl/etl/cdm_observation.sql
@@ -24,7 +24,7 @@
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_observation
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_observation
 (
     observation_id                INT64     not null ,
     person_id                     INT64     not null ,
@@ -57,7 +57,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_observation
 -- lk_observation_mapped (demographics and DRG codes)
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_observation
+INSERT INTO @etl_project.@etl_dataset.cdm_observation
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS observation_id,
     per.person_id                               AS person_id,
@@ -85,12 +85,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_observation_mapped src
+    @etl_project.@etl_dataset.lk_observation_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -102,7 +102,7 @@ WHERE
 -- chartevents
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_observation
+INSERT INTO @etl_project.@etl_dataset.cdm_observation
 SELECT
     src.measurement_id                          AS observation_id, -- id is generated already
     per.person_id                               AS person_id,
@@ -130,12 +130,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_chartevents_mapped src
+    @etl_project.@etl_dataset.lk_chartevents_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -147,7 +147,7 @@ WHERE
 -- lk_procedure_mapped
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_observation
+INSERT INTO @etl_project.@etl_dataset.cdm_observation
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS observation_id,
     per.person_id                               AS person_id,
@@ -173,12 +173,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_procedure_mapped src
+    @etl_project.@etl_dataset.lk_procedure_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -190,7 +190,7 @@ WHERE
 -- diagnoses
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_observation
+INSERT INTO @etl_project.@etl_dataset.cdm_observation
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS observation_id,
     per.person_id                               AS person_id,
@@ -216,12 +216,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_diagnoses_icd_mapped src
+    @etl_project.@etl_dataset.lk_diagnoses_icd_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -233,7 +233,7 @@ WHERE
 -- lk_specimen_mapped
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_observation
+INSERT INTO @etl_project.@etl_dataset.cdm_observation
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS observation_id,
     per.person_id                               AS person_id,
@@ -259,12 +259,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_specimen_mapped src
+    @etl_project.@etl_dataset.lk_specimen_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', 
                 COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))

--- a/etl/etl/cdm_observation_period.sql
+++ b/etl/etl/cdm_observation_period.sql
@@ -22,110 +22,110 @@
 -- tmp_observation_period_clean
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.tmp_observation_period_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.tmp_observation_period_clean AS
 SELECT
     src.person_id               AS person_id,
     MIN(src.visit_start_date)   AS start_date,
     MAX(src.visit_end_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence src
+    @etl_project.@etl_dataset.cdm_visit_occurrence src
 GROUP BY
     src.person_id, src.unit_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.tmp_observation_period_clean
+INSERT INTO @etl_project.@etl_dataset.tmp_observation_period_clean
 SELECT
     src.person_id               AS person_id,
     MIN(src.condition_start_date)   AS start_date,
     MAX(src.condition_end_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence src
+    @etl_project.@etl_dataset.cdm_condition_occurrence src
 GROUP BY
     src.person_id, src.unit_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.tmp_observation_period_clean
+INSERT INTO @etl_project.@etl_dataset.tmp_observation_period_clean
 SELECT
     src.person_id               AS person_id,
     MIN(src.procedure_date)   AS start_date,
     MAX(src.procedure_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_procedure_occurrence src
+    @etl_project.@etl_dataset.cdm_procedure_occurrence src
 GROUP BY
     src.person_id, src.unit_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.tmp_observation_period_clean
+INSERT INTO @etl_project.@etl_dataset.tmp_observation_period_clean
 SELECT
     src.person_id               AS person_id,
     MIN(src.drug_exposure_start_date)   AS start_date,
     MAX(src.drug_exposure_end_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_drug_exposure src
+    @etl_project.@etl_dataset.cdm_drug_exposure src
 GROUP BY
     src.person_id, src.unit_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.tmp_observation_period_clean
+INSERT INTO @etl_project.@etl_dataset.tmp_observation_period_clean
 SELECT
     src.person_id               AS person_id,
     MIN(src.device_exposure_start_date)   AS start_date,
     MAX(src.device_exposure_end_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_device_exposure src
+    @etl_project.@etl_dataset.cdm_device_exposure src
 GROUP BY
     src.person_id, src.unit_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.tmp_observation_period_clean
+INSERT INTO @etl_project.@etl_dataset.tmp_observation_period_clean
 SELECT
     src.person_id               AS person_id,
     MIN(src.measurement_date)   AS start_date,
     MAX(src.measurement_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_measurement src
+    @etl_project.@etl_dataset.cdm_measurement src
 GROUP BY
     src.person_id, src.unit_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.tmp_observation_period_clean
+INSERT INTO @etl_project.@etl_dataset.tmp_observation_period_clean
 SELECT
     src.person_id               AS person_id,
     MIN(src.specimen_date)   AS start_date,
     MAX(src.specimen_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_specimen src
+    @etl_project.@etl_dataset.cdm_specimen src
 GROUP BY
     src.person_id, src.unit_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.tmp_observation_period_clean
+INSERT INTO @etl_project.@etl_dataset.tmp_observation_period_clean
 SELECT
     src.person_id               AS person_id,
     MIN(src.observation_date)   AS start_date,
     MAX(src.observation_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_observation src
+    @etl_project.@etl_dataset.cdm_observation src
 GROUP BY
     src.person_id, src.unit_id
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.tmp_observation_period_clean
+INSERT INTO @etl_project.@etl_dataset.tmp_observation_period_clean
 SELECT
     src.person_id               AS person_id,
     MIN(src.death_date)         AS start_date,
     MAX(src.death_date)         AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.cdm_death src
+    @etl_project.@etl_dataset.cdm_death src
 GROUP BY
     src.person_id, src.unit_id
 ;
@@ -135,14 +135,14 @@ GROUP BY
 -- tmp_observation_period
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.tmp_observation_period AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.tmp_observation_period AS
 SELECT
     src.person_id               AS person_id,
     MIN(src.start_date)   AS start_date,
     MAX(src.end_date)     AS end_date,
     src.unit_id                 AS unit_id
 FROM
-    `@etl_project`.@etl_dataset.tmp_observation_period_clean src
+    @etl_project.@etl_dataset.tmp_observation_period_clean src
 GROUP BY
     src.person_id, src.unit_id
 ;
@@ -152,7 +152,7 @@ GROUP BY
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_observation_period
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_observation_period
 (
     observation_period_id             INT64   not null ,
     person_id                         INT64   not null ,
@@ -167,7 +167,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_observation_period
 )
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_observation_period
+INSERT INTO @etl_project.@etl_dataset.cdm_observation_period
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS observation_period_id,
     src.person_id                               AS person_id,
@@ -180,7 +180,7 @@ SELECT
     0                                           AS load_row_id,
     CAST(NULL AS STRING)                        AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.tmp_observation_period src
+    @etl_project.@etl_dataset.tmp_observation_period src
 GROUP BY
     src.person_id
 ;
@@ -189,5 +189,5 @@ GROUP BY
 -- cleanup
 -- -------------------------------------------------------------------
 
--- DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.tmp_observation_period_clean;
--- DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.tmp_observation_period;
+-- DROP TABLE IF EXISTS @etl_project.@etl_dataset.tmp_observation_period_clean;
+-- DROP TABLE IF EXISTS @etl_project.@etl_dataset.tmp_observation_period;

--- a/etl/etl/cdm_person.sql
+++ b/etl/etl/cdm_person.sql
@@ -14,7 +14,7 @@
 -- Known issues / Open points:
 --
 -- TRUNCATE TABLE is not supported, organize "create or replace"
--- `@etl_project`.@etl_dataset.cdm_person;
+-- @etl_project.@etl_dataset.cdm_person;
 --
 -- negative unique id from FARM_FINGERPRINT(GENERATE_UUID())
 --
@@ -29,21 +29,21 @@
 -- tmp_subject_ethnicity
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.tmp_subject_ethnicity AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.tmp_subject_ethnicity AS
 SELECT DISTINCT
     src.subject_id                      AS subject_id,
     FIRST_VALUE(src.ethnicity) OVER (
         PARTITION BY src.subject_id 
         ORDER BY src.admittime ASC)     AS ethnicity_first
 FROM
-    `@etl_project`.@etl_dataset.src_admissions src
+    @etl_project.@etl_dataset.src_admissions src
 ;
 
 -- -------------------------------------------------------------------
 -- lk_pat_ethnicity_concept
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_pat_ethnicity_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_pat_ethnicity_concept AS
 SELECT DISTINCT
     src.ethnicity_first     AS source_code,
     vc.concept_id           AS source_concept_id,
@@ -51,18 +51,18 @@ SELECT DISTINCT
     vc1.concept_id          AS target_concept_id,
     vc1.vocabulary_id       AS target_vocabulary_id -- look here to distinguish Race and Ethnicity
 FROM
-    `@etl_project`.@etl_dataset.tmp_subject_ethnicity src
+    @etl_project.@etl_dataset.tmp_subject_ethnicity src
 LEFT JOIN
     -- gcpt_ethnicity_to_concept -> mimiciv_per_ethnicity
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON UPPER(vc.concept_code) = UPPER(src.ethnicity_first) -- do the custom mapping
         AND vc.domain_id IN ('Race', 'Ethnicity')
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship cr1
+    @etl_project.@etl_dataset.voc_concept_relationship cr1
         ON  cr1.concept_id_1 = vc.concept_id
         AND cr1.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc1
+    @etl_project.@etl_dataset.voc_concept vc1
         ON  cr1.concept_id_2 = vc1.concept_id
         AND vc1.invalid_reason IS NULL
         AND vc1.standard_concept = 'S'
@@ -73,7 +73,7 @@ LEFT JOIN
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_person
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_person
 (
     person_id                   INT64     not null ,
     gender_concept_id           INT64     not null ,
@@ -101,7 +101,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_person
 )
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_person
+INSERT INTO @etl_project.@etl_dataset.cdm_person
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID()) AS person_id,
     CASE 
@@ -159,12 +159,12 @@ SELECT
     p.load_row_id                   AS load_row_id,
     p.trace_id                      AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.src_patients p
+    @etl_project.@etl_dataset.src_patients p
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.tmp_subject_ethnicity eth 
+    @etl_project.@etl_dataset.tmp_subject_ethnicity eth 
         ON  p.subject_id = eth.subject_id
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_pat_ethnicity_concept map_eth
+    @etl_project.@etl_dataset.lk_pat_ethnicity_concept map_eth
         ON  eth.ethnicity_first = map_eth.source_code
 ;
 
@@ -173,4 +173,4 @@ LEFT JOIN
 -- cleanup
 -- -------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.tmp_subject_ethnicity;
+DROP TABLE IF EXISTS @etl_project.@etl_dataset.tmp_subject_ethnicity;

--- a/etl/etl/cdm_procedure_occurrence.sql
+++ b/etl/etl/cdm_procedure_occurrence.sql
@@ -25,7 +25,7 @@
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_procedure_occurrence
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_procedure_occurrence
 (
     procedure_occurrence_id     INT64     not null ,
     person_id                   INT64     not null ,
@@ -54,7 +54,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_procedure_occurrence
 -- lk_procedure_mapped
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_procedure_occurrence
+INSERT INTO @etl_project.@etl_dataset.cdm_procedure_occurrence
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS procedure_occurrence_id,
     per.person_id                               AS person_id,
@@ -76,12 +76,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_procedure_mapped src
+    @etl_project.@etl_dataset.lk_procedure_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -93,7 +93,7 @@ WHERE
 -- lk_observation_mapped, possible DRG codes
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_procedure_occurrence
+INSERT INTO @etl_project.@etl_dataset.cdm_procedure_occurrence
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS procedure_occurrence_id,
     per.person_id                               AS person_id,
@@ -115,12 +115,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_observation_mapped src
+    @etl_project.@etl_dataset.lk_observation_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE
@@ -132,7 +132,7 @@ WHERE
 -- lk_specimen_mapped, small part of specimen is mapped to Procedure
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_procedure_occurrence
+INSERT INTO @etl_project.@etl_dataset.cdm_procedure_occurrence
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS procedure_occurrence_id,
     per.person_id                               AS person_id,
@@ -154,12 +154,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_specimen_mapped src
+    @etl_project.@etl_dataset.lk_specimen_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', 
                 COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
@@ -173,7 +173,7 @@ WHERE
 -- lk_chartevents_mapped, a part of chartevents table is mapped to Procedure
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_procedure_occurrence
+INSERT INTO @etl_project.@etl_dataset.cdm_procedure_occurrence
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS procedure_occurrence_id,
     per.person_id                               AS person_id,
@@ -195,12 +195,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_chartevents_mapped src
+    @etl_project.@etl_dataset.lk_chartevents_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
 WHERE

--- a/etl/etl/cdm_specimen.sql
+++ b/etl/etl/cdm_specimen.sql
@@ -27,7 +27,7 @@
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_specimen
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_specimen
 (
     specimen_id                 INT64     not null ,
     person_id                   INT64     not null ,
@@ -53,7 +53,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_specimen
 ;
 
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_specimen
+INSERT INTO @etl_project.@etl_dataset.cdm_specimen
 SELECT
     src.specimen_id                             AS specimen_id,
     per.person_id                               AS person_id,
@@ -76,9 +76,9 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_specimen_mapped src
+    @etl_project.@etl_dataset.lk_specimen_mapped src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 WHERE
     src.target_domain_id = 'Specimen'

--- a/etl/etl/cdm_visit_detail.sql
+++ b/etl/etl/cdm_visit_detail.sql
@@ -29,7 +29,7 @@
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_visit_detail
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_visit_detail
 (
     visit_detail_id                    INT64     not null ,
     person_id                          INT64     not null ,
@@ -66,7 +66,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_visit_detail
 
 
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_visit_detail
+INSERT INTO @etl_project.@etl_dataset.cdm_visit_detail
 SELECT
     src.visit_detail_id                     AS visit_detail_id,
     per.person_id                           AS person_id,
@@ -102,25 +102,25 @@ SELECT
     src.load_row_id                   AS load_row_id,
     src.trace_id                      AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_visit_detail_prev_next src
+    @etl_project.@etl_dataset.lk_visit_detail_prev_next src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per 
+    @etl_project.@etl_dataset.cdm_person per 
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence vis 
+    @etl_project.@etl_dataset.cdm_visit_occurrence vis 
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', 
                 COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_care_site cs
+    @etl_project.@etl_dataset.cdm_care_site cs
         ON cs.care_site_source_value = src.current_location
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_visit_concept vdc
+    @etl_project.@etl_dataset.lk_visit_concept vdc
         ON vdc.source_code = src.current_location
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_visit_concept la 
+    @etl_project.@etl_dataset.lk_visit_concept la 
         ON la.source_code = src.admission_location
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_visit_concept ld
+    @etl_project.@etl_dataset.lk_visit_concept ld
         ON ld.source_code = src.discharge_location
 ;

--- a/etl/etl/cdm_visit_occurrence.sql
+++ b/etl/etl/cdm_visit_occurrence.sql
@@ -37,7 +37,7 @@
 -- -------------------------------------------------------------------
 
 --HINT DISTRIBUTE_ON_KEY(person_id)
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_visit_occurrence
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_visit_occurrence
 (
     visit_occurrence_id           INT64     not null ,
     person_id                     INT64     not null ,
@@ -64,7 +64,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.cdm_visit_occurrence
 )
 ;
 
-INSERT INTO `@etl_project`.@etl_dataset.cdm_visit_occurrence
+INSERT INTO @etl_project.@etl_dataset.cdm_visit_occurrence
 SELECT
     src.visit_occurrence_id                 AS visit_occurrence_id,
     per.person_id                           AS person_id,
@@ -98,20 +98,20 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.lk_visit_clean src
+    @etl_project.@etl_dataset.lk_visit_clean src
 INNER JOIN
-    `@etl_project`.@etl_dataset.cdm_person per
+    @etl_project.@etl_dataset.cdm_person per
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.lk_visit_concept lat
+    @etl_project.@etl_dataset.lk_visit_concept lat
         ON lat.source_code = src.admission_type
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.lk_visit_concept la 
+    @etl_project.@etl_dataset.lk_visit_concept la 
         ON la.source_code = src.admission_location
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.lk_visit_concept ld
+    @etl_project.@etl_dataset.lk_visit_concept ld
         ON ld.source_code = src.discharge_location
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.cdm_care_site cs
+    @etl_project.@etl_dataset.cdm_care_site cs
         ON care_site_name = 'BIDMC' -- Beth Israel hospital for all
 ;

--- a/etl/etl/ext_d_itemid_to_concept.sql
+++ b/etl/etl/ext_d_itemid_to_concept.sql
@@ -11,7 +11,7 @@
 -- -------------------------------------------------------------------
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.d_items_to_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.d_items_to_concept AS
 WITH
 counts AS
 (
@@ -25,7 +25,7 @@ counts AS
         src.target_concept_id       AS target_concept_id,
         COUNT(*)                    AS row_count
     FROM
-        `@etl_project`.@etl_dataset.lk_chartevents_mapped src
+        @etl_project.@etl_dataset.lk_chartevents_mapped src
     GROUP BY
         src.itemid,
         src.source_label,
@@ -45,7 +45,7 @@ counts AS
         src.target_concept_id       AS target_concept_id,
         COUNT(*)                    AS row_count
     FROM
-        `@etl_project`.@etl_dataset.lk_procedure_mapped src
+        @etl_project.@etl_dataset.lk_procedure_mapped src
     WHERE
         src.unit_id LIKE '%.procedureevents'
         OR src.unit_id LIKE '%.datetimeevents'
@@ -75,10 +75,10 @@ SELECT
 FROM
     counts src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON  src.source_concept_id = vc.concept_id
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON src.target_concept_id = vc2.concept_id
 ORDER BY
     itemid, target_vocabulary_id, target_concept_id
@@ -88,14 +88,14 @@ ORDER BY
 -- d_labitems.itemid to concept_id
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.d_labitems_to_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.d_labitems_to_concept AS
 WITH
 counts AS
 (
     SELECT
         itemid AS itemid, COUNT(*) AS row_count
     FROM
-        `@etl_project`.@etl_dataset.lk_meas_labevents_mapped
+        @etl_project.@etl_dataset.lk_meas_labevents_mapped
     GROUP BY itemid
 )
 SELECT
@@ -116,7 +116,7 @@ SELECT
     src.target_standard_concept     AS target_standard_concept, -- for double-check
     counts.row_count                AS row_count
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_d_labitems_concept src
+    @etl_project.@etl_dataset.lk_meas_d_labitems_concept src
 LEFT JOIN
     counts 
         USING (itemid)
@@ -129,32 +129,32 @@ ORDER BY
 -- d_micro.itemid to concept_id
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.d_micro_to_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.d_micro_to_concept AS
 WITH
 counts AS
 (
     SELECT
         spec_itemid AS itemid, COUNT(*) AS row_count
     FROM
-        `@etl_project`.@etl_dataset.lk_specimen_mapped
+        @etl_project.@etl_dataset.lk_specimen_mapped
     GROUP BY itemid
     UNION ALL -- more unions
     SELECT
         test_itemid AS itemid, COUNT(*) AS row_count
     FROM
-        `@etl_project`.@etl_dataset.lk_meas_organism_mapped
+        @etl_project.@etl_dataset.lk_meas_organism_mapped
     GROUP BY itemid
     UNION ALL -- more unions
     SELECT
         org_itemid AS itemid, COUNT(*) AS row_count
     FROM
-        `@etl_project`.@etl_dataset.lk_meas_organism_mapped
+        @etl_project.@etl_dataset.lk_meas_organism_mapped
     GROUP BY itemid
     UNION ALL
     SELECT
         ab_itemid AS itemid, COUNT(*) AS row_count
     FROM
-        `@etl_project`.@etl_dataset.lk_meas_ab_mapped
+        @etl_project.@etl_dataset.lk_meas_ab_mapped
     GROUP BY itemid
 )
 SELECT
@@ -174,15 +174,15 @@ SELECT
     src.target_standard_concept     AS target_standard_concept, -- for double-check
     counts.row_count                AS row_count
 FROM
-    `@etl_project`.@etl_dataset.lk_d_micro_concept src
+    @etl_project.@etl_dataset.lk_d_micro_concept src
 LEFT JOIN
     counts 
         USING (itemid)
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON  src.source_concept_id = vc.concept_id
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON src.target_concept_id = vc2.concept_id
 ORDER BY
     itemid, target_vocabulary_id, target_concept_id

--- a/etl/etl/lk_cond_diagnoses.sql
+++ b/etl/etl/lk_cond_diagnoses.sql
@@ -32,7 +32,7 @@
 -- lk_diagnoses_icd_clean
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_diagnoses_icd_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_diagnoses_icd_clean AS
 SELECT
     src.subject_id                              AS subject_id,
     src.hadm_id                                 AS hadm_id,
@@ -54,9 +54,9 @@ SELECT
     src.load_row_id         AS load_row_id,
     src.trace_id            AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_diagnoses_icd src
+    @etl_project.@etl_dataset.src_diagnoses_icd src
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_admissions adm
+    @etl_project.@etl_dataset.src_admissions adm
         ON  src.hadm_id = adm.hadm_id
 ;
 
@@ -66,7 +66,7 @@ INNER JOIN
 -- but create mapped table, which goes to Condition and Drug as well
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_diagnoses_icd_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_diagnoses_icd_mapped AS
 SELECT
     src.subject_id                      AS subject_id,
     src.hadm_id                         AS hadm_id,
@@ -87,17 +87,17 @@ SELECT
     src.load_row_id         AS load_row_id,
     src.trace_id            AS trace_id  
 FROM
-    `@etl_project`.@etl_dataset.lk_diagnoses_icd_clean src
+    @etl_project.@etl_dataset.lk_diagnoses_icd_clean src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON REPLACE(vc.concept_code, '.', '') = REPLACE(TRIM(src.source_code), '.', '')
         AND vc.vocabulary_id = src.source_vocabulary_id
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL
@@ -112,4 +112,4 @@ LEFT JOIN
 -- cleanup
 -- -------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.tmp_seq_num_to_concept;
+DROP TABLE IF EXISTS @etl_project.@etl_dataset.tmp_seq_num_to_concept;

--- a/etl/etl/lk_drug.sql
+++ b/etl/etl/lk_drug.sql
@@ -27,7 +27,7 @@
 -- lk_prescriptions_clean 
 -- Rule 1
 -- -------------------------------------------------------------------
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_prescriptions_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_prescriptions_clean AS
 SELECT
     -- -- 'drug:['                || COALESCE(drug, drug_name_poe, drug_name_generic,'') || ']'||
     -- 'drug:['                || COALESCE(drug,'') || ']'||
@@ -67,9 +67,9 @@ SELECT
     src.trace_id                    AS trace_id
 
 FROM
-    `@etl_project`.@etl_dataset.src_prescriptions src -- pr
+    @etl_project.@etl_dataset.src_prescriptions src -- pr
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.src_pharmacy pharm
+    @etl_project.@etl_dataset.src_pharmacy pharm
         ON src.pharmacy_id = pharm.pharmacy_id
 WHERE
     src.starttime IS NOT NULL
@@ -81,7 +81,7 @@ WHERE
 -- Rule 1
 -- mapping is 85% done from gsn coding
 -- -------------------------------------------------------------------
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_pr_ndc_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_pr_ndc_concept AS
 SELECT DISTINCT
     src.ndc_source_code     AS source_code,
     vc.domain_id            AS source_domain_id,
@@ -89,17 +89,17 @@ SELECT DISTINCT
     vc2.domain_id           AS target_domain_id,
     vc2.concept_id          AS target_concept_id
 FROM
-    `@etl_project`.@etl_dataset.lk_prescriptions_clean src -- pr
+    @etl_project.@etl_dataset.lk_prescriptions_clean src -- pr
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON  vc.concept_code = src.ndc_source_code --this covers 85% of direct mapping but no standard
         AND vc.vocabulary_id = src.ndc_source_vocabulary -- NDC
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1 
         and vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL --covers 71% of rxnorm standards concepts
@@ -109,7 +109,7 @@ LEFT JOIN
 -- lk_pr_gcpt_concept
 -- Rule 1
 -- -------------------------------------------------------------------
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_pr_gcpt_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_pr_gcpt_concept AS
 SELECT DISTINCT
     src.gcpt_source_code    AS source_code,
     vc.domain_id            AS source_domain_id,
@@ -117,17 +117,17 @@ SELECT DISTINCT
     vc2.domain_id           AS target_domain_id,
     vc2.concept_id          AS target_concept_id
 FROM
-    `@etl_project`.@etl_dataset.lk_prescriptions_clean src -- pr
+    @etl_project.@etl_dataset.lk_prescriptions_clean src -- pr
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON  vc.concept_code = src.gcpt_source_code
         AND vc.vocabulary_id = src.gcpt_source_vocabulary -- mimiciv_drug_ndc
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1 
         and vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL --covers 71% of rxnorm standards concepts
@@ -137,7 +137,7 @@ LEFT JOIN
 -- lk_pr_route_concept
 -- Rule 1
 -- -------------------------------------------------------------------
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_pr_route_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_pr_route_concept AS
 SELECT DISTINCT
     src.route_source_code   AS source_code,
     vc.domain_id            AS source_domain_id,
@@ -145,17 +145,17 @@ SELECT DISTINCT
     vc2.domain_id           AS target_domain_id,
     vc2.concept_id          AS target_concept_id
 FROM
-    `@etl_project`.@etl_dataset.lk_prescriptions_clean src -- pr
+    @etl_project.@etl_dataset.lk_prescriptions_clean src -- pr
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON  vc.concept_code = src.route_source_code
         AND vc.vocabulary_id = src.route_source_vocabulary
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1 
         and vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL --covers 71% of rxnorm standards concepts
@@ -165,7 +165,7 @@ LEFT JOIN
 -- lk_drug_mapped
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_drug_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_drug_mapped AS
 SELECT
     src.hadm_id                                     AS hadm_id,
     src.subject_id                                  AS subject_id,
@@ -191,17 +191,17 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_prescriptions_clean src
+    @etl_project.@etl_dataset.lk_prescriptions_clean src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_pr_ndc_concept vc_ndc
+    @etl_project.@etl_dataset.lk_pr_ndc_concept vc_ndc
         ON  src.ndc_source_code = vc_ndc.source_code
         AND vc_ndc.target_concept_id IS NOT NULL
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_pr_gcpt_concept vc_gcpt
+    @etl_project.@etl_dataset.lk_pr_gcpt_concept vc_gcpt
         ON  src.gcpt_source_code = vc_gcpt.source_code
         AND vc_gcpt.target_concept_id IS NOT NULL
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_pr_route_concept vc_route
+    @etl_project.@etl_dataset.lk_pr_route_concept vc_route
         ON src.route_source_code = vc_route.source_code
         AND vc_route.target_concept_id IS NOT NULL
 ;

--- a/etl/etl/lk_meas_labevents.sql
+++ b/etl/etl/lk_meas_labevents.sql
@@ -25,7 +25,7 @@
 -- src_labevents.value: 
 --      investigate if there are formatted values with thousand separators,
 --      and if we need to use more complicated parsing.
---      see `@etl_project`.@etl_dataset.an_labevents_full
+--      see @etl_project.@etl_dataset.an_labevents_full
 --      see a possibility to use 'Maps to value'
 -- custom mapping:
 --      gcpt_lab_label_to_concept -> mimiciv_meas_lab_loinc
@@ -43,7 +43,7 @@
 -- source code represented in cdm tables: itemid
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_d_labitems_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_d_labitems_clean AS
 SELECT
     dlab.itemid                                                 AS itemid, -- for <cdm>.<source_value>
     COALESCE(dlab.loinc_code, 
@@ -55,7 +55,7 @@ SELECT
         'mimiciv_meas_lab_loinc'
     )                                                           AS source_vocabulary_id
 FROM
-    `@etl_project`.@etl_dataset.src_d_labitems dlab
+    @etl_project.@etl_dataset.src_d_labitems dlab
 ;
 
 -- -------------------------------------------------------------------
@@ -64,7 +64,7 @@ FROM
 -- filter: only valid itemid (100%)
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_labevents_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_labevents_clean AS
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())       AS measurement_id,
     src.subject_id                          AS subject_id,
@@ -83,9 +83,9 @@ SELECT
     src.load_row_id         AS load_row_id,
     src.trace_id            AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_labevents src
+    @etl_project.@etl_dataset.src_labevents src
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_d_labitems dlab
+    @etl_project.@etl_dataset.src_d_labitems dlab
         ON src.itemid = dlab.itemid
 ;
 
@@ -94,7 +94,7 @@ INNER JOIN
 --  gcpt_lab_label_to_concept -> mimiciv_meas_lab_loinc
 -- all dlab.itemid, all available concepts from LOINC and custom mapped dlab.label
 -- -------------------------------------------------------------------
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_d_labitems_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_d_labitems_concept AS
 SELECT
     dlab.itemid                 AS itemid,
     dlab.source_code            AS source_code,
@@ -112,18 +112,18 @@ SELECT
     vc2.concept_name            AS target_concept_name,
     vc2.standard_concept        AS target_standard_concept
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_d_labitems_clean dlab
+    @etl_project.@etl_dataset.lk_meas_d_labitems_clean dlab
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON  vc.concept_code = dlab.source_code -- join 
         AND vc.vocabulary_id = dlab.source_vocabulary_id
         -- AND vc.domain_id = 'Measurement'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL
@@ -135,7 +135,7 @@ LEFT JOIN
 -- row_num is added to select the earliest if more than one hadm_ids are found
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_labevents_hadm_id AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_labevents_hadm_id AS
 SELECT
     src.trace_id                        AS event_trace_id, 
     adm.hadm_id                         AS hadm_id,
@@ -144,9 +144,9 @@ SELECT
         ORDER BY adm.start_datetime
     )                                   AS row_num
 FROM  
-    `@etl_project`.@etl_dataset.lk_meas_labevents_clean src
+    @etl_project.@etl_dataset.lk_meas_labevents_clean src
 INNER JOIN 
-    `@etl_project`.@etl_dataset.lk_admissions_clean adm
+    @etl_project.@etl_dataset.lk_admissions_clean adm
         ON adm.subject_id = src.subject_id
         AND src.start_datetime BETWEEN adm.start_datetime AND adm.end_datetime
 WHERE
@@ -159,7 +159,7 @@ WHERE
 -- measurement_source_value: itemid
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_labevents_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_labevents_mapped AS
 SELECT
     src.measurement_id                      AS measurement_id,
     src.subject_id                          AS subject_id,
@@ -188,18 +188,18 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM  
-    `@etl_project`.@etl_dataset.lk_meas_labevents_clean src
+    @etl_project.@etl_dataset.lk_meas_labevents_clean src
 INNER JOIN 
-    `@etl_project`.@etl_dataset.lk_meas_d_labitems_concept labc
+    @etl_project.@etl_dataset.lk_meas_d_labitems_concept labc
         ON labc.itemid = src.itemid
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.lk_meas_operator_concept opc
+    @etl_project.@etl_dataset.lk_meas_operator_concept opc
         ON opc.source_code = src.value_operator
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.lk_meas_unit_concept uc
+    @etl_project.@etl_dataset.lk_meas_unit_concept uc
         ON uc.source_code = src.valueuom
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.lk_meas_labevents_hadm_id hadm
+    @etl_project.@etl_dataset.lk_meas_labevents_hadm_id hadm
         ON hadm.event_trace_id = src.trace_id
         AND hadm.row_num = 1
 ;

--- a/etl/etl/lk_meas_specimen.sql
+++ b/etl/etl/lk_meas_specimen.sql
@@ -33,7 +33,7 @@
 -- group microevent_id = trace_id for each type of records
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_micro_cross_ref AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_micro_cross_ref AS
 SELECT
     trace_id                                    AS trace_id_ab, -- for antibiotics
     FIRST_VALUE(src.trace_id) OVER (
@@ -58,7 +58,7 @@ SELECT
     hadm_id                                     AS hadm_id,
     COALESCE(src.charttime, src.chartdate)      AS start_datetime -- just to do coalesce once
 FROM
-    `@etl_project`.@etl_dataset.src_microbiologyevents src -- mbe
+    @etl_project.@etl_dataset.src_microbiologyevents src -- mbe
 ;
 
 -- -------------------------------------------------------------------
@@ -67,7 +67,7 @@ FROM
 -- row_num is added to select the earliest if more than one hadm_ids are found
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_micro_hadm_id AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_micro_hadm_id AS
 SELECT
     src.trace_id_ab                     AS event_trace_id,
     adm.hadm_id                         AS hadm_id,
@@ -76,9 +76,9 @@ SELECT
         ORDER BY adm.start_datetime
     )                                   AS row_num
 FROM  
-    `@etl_project`.@etl_dataset.lk_micro_cross_ref src
+    @etl_project.@etl_dataset.lk_micro_cross_ref src
 INNER JOIN 
-    `@etl_project`.@etl_dataset.lk_admissions_clean adm
+    @etl_project.@etl_dataset.lk_admissions_clean adm
         ON adm.subject_id = src.subject_id
         AND src.start_datetime BETWEEN adm.start_datetime AND adm.end_datetime
 WHERE
@@ -89,7 +89,7 @@ WHERE
 -- Part 2 of microbiology: test taken and organisms grown in the material of the test
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_organism_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_organism_clean AS
 SELECT DISTINCT
     src.subject_id                              AS subject_id,
     src.hadm_id                                 AS hadm_id,
@@ -104,9 +104,9 @@ SELECT DISTINCT
     0                               AS load_row_id,
     cr.trace_id_org                 AS trace_id         -- trace_id for test-organism
 FROM
-    `@etl_project`.@etl_dataset.src_microbiologyevents src -- mbe
+    @etl_project.@etl_dataset.src_microbiologyevents src -- mbe
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_micro_cross_ref cr
+    @etl_project.@etl_dataset.lk_micro_cross_ref cr
         ON src.trace_id = cr.trace_id_org
 ;
 
@@ -114,7 +114,7 @@ INNER JOIN
 -- Part 1 of microbiology: specimen
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_specimen_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_specimen_clean AS
 SELECT DISTINCT
     src.subject_id                              AS subject_id,
     src.hadm_id                                 AS hadm_id,
@@ -126,9 +126,9 @@ SELECT DISTINCT
     0                               AS load_row_id,
     cr.trace_id_spec                AS trace_id         -- trace_id for specimen
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_organism_clean src -- mbe
+    @etl_project.@etl_dataset.lk_meas_organism_clean src -- mbe
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_micro_cross_ref cr
+    @etl_project.@etl_dataset.lk_micro_cross_ref cr
         ON src.trace_id = cr.trace_id_spec
 ;
 
@@ -136,7 +136,7 @@ INNER JOIN
 -- Part 3 of microbiology: antibiotics tested on organisms
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_ab_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_ab_clean AS
 SELECT
     src.subject_id                              AS subject_id,
     src.hadm_id                                 AS hadm_id,
@@ -152,9 +152,9 @@ SELECT
     0                               AS load_row_id,
     src.trace_id                    AS trace_id         -- trace_id for antibiotics, no groupping is needed
 FROM
-    `@etl_project`.@etl_dataset.src_microbiologyevents src
+    @etl_project.@etl_dataset.src_microbiologyevents src
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_micro_cross_ref cr
+    @etl_project.@etl_dataset.lk_micro_cross_ref cr
         ON src.trace_id = cr.trace_id_ab
 WHERE
     src.ab_itemid IS NOT NULL
@@ -166,14 +166,14 @@ WHERE
 -- source_label for organism: test name plus specimen name
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_d_micro_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_d_micro_clean AS
 SELECT
     dm.itemid                                       AS itemid,
     CAST(dm.itemid AS STRING)                       AS source_code,
     dm.label                                        AS source_label, -- for organism_mapped: test name plus specimen name
     CONCAT('mimiciv_micro_', LOWER(dm.category))    AS source_vocabulary_id,
 FROM
-    `@etl_project`.@etl_dataset.src_d_micro dm
+    @etl_project.@etl_dataset.src_d_micro dm
 UNION ALL
 SELECT DISTINCT
     CAST(NULL AS INT64)                             AS itemid,
@@ -181,7 +181,7 @@ SELECT DISTINCT
     src.interpretation                              AS source_label,
     'mimiciv_micro_resistance'                      AS source_vocabulary_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_ab_clean src
+    @etl_project.@etl_dataset.lk_meas_ab_clean src
 WHERE
     src.interpretation IS NOT NULL
 ;
@@ -202,7 +202,7 @@ WHERE
 --        src_microbiologyevents.interpretation -> source_code
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_d_micro_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_d_micro_concept AS
 SELECT
     dm.itemid                   AS itemid,
     dm.source_code              AS source_code, -- itemid
@@ -219,9 +219,9 @@ SELECT
     vc2.concept_name            AS target_concept_name,
     vc2.standard_concept        AS target_standard_concept
 FROM
-    `@etl_project`.@etl_dataset.lk_d_micro_clean dm
+    @etl_project.@etl_dataset.lk_d_micro_clean dm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON  dm.source_code = vc.concept_code
         -- gcpt_microbiology_specimen_to_concept -> mimiciv_micro_specimen
         -- (gcpt) brand new vocab -> mimiciv_micro_test
@@ -229,11 +229,11 @@ LEFT JOIN
         -- (gcpt) brand new vocab -> mimiciv_micro_resistance
         AND vc.vocabulary_id = dm.source_vocabulary_id
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL
@@ -243,7 +243,7 @@ LEFT JOIN
 -- lk_specimen_mapped
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_specimen_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_specimen_mapped AS
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS specimen_id,
     src.subject_id                              AS subject_id,
@@ -263,12 +263,12 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_specimen_clean src
+    @etl_project.@etl_dataset.lk_specimen_clean src
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_d_micro_concept mc
+    @etl_project.@etl_dataset.lk_d_micro_concept mc
         ON src.spec_itemid = mc.itemid
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_micro_hadm_id hadm
+    @etl_project.@etl_dataset.lk_micro_hadm_id hadm
         ON hadm.event_trace_id = src.trace_id
         AND hadm.row_num = 1
 ;
@@ -277,7 +277,7 @@ LEFT JOIN
 -- lk_meas_organism_mapped
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_organism_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_organism_mapped AS
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS measurement_id,
     src.subject_id                              AS subject_id,
@@ -303,18 +303,18 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_organism_clean src
+    @etl_project.@etl_dataset.lk_meas_organism_clean src
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_d_micro_concept tc
+    @etl_project.@etl_dataset.lk_d_micro_concept tc
         ON src.test_itemid = tc.itemid
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_d_micro_concept sc
+    @etl_project.@etl_dataset.lk_d_micro_concept sc
         ON src.spec_itemid = sc.itemid
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_d_micro_concept oc
+    @etl_project.@etl_dataset.lk_d_micro_concept oc
         ON src.org_itemid = oc.itemid
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_micro_hadm_id hadm
+    @etl_project.@etl_dataset.lk_micro_hadm_id hadm
         ON hadm.event_trace_id = src.trace_id
         AND hadm.row_num = 1
 ;
@@ -326,7 +326,7 @@ LEFT JOIN
 --          mbe.interpretation -> source_code -> 4 rows for resistance degrees.
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_ab_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_ab_mapped AS
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())           AS measurement_id,
     src.subject_id                              AS subject_id,
@@ -352,19 +352,19 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_ab_clean src
+    @etl_project.@etl_dataset.lk_meas_ab_clean src
 INNER JOIN
-    `@etl_project`.@etl_dataset.lk_d_micro_concept ac
+    @etl_project.@etl_dataset.lk_d_micro_concept ac
         ON src.ab_itemid = ac.itemid
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_d_micro_concept rc
+    @etl_project.@etl_dataset.lk_d_micro_concept rc
         ON src.interpretation = rc.source_code
         AND rc.source_vocabulary_id = 'mimiciv_micro_resistance' -- new vocab
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_meas_operator_concept opc -- see lk_meas_labevents.sql
+    @etl_project.@etl_dataset.lk_meas_operator_concept opc -- see lk_meas_labevents.sql
         ON src.dilution_comparison = opc.source_code
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_micro_hadm_id hadm
+    @etl_project.@etl_dataset.lk_micro_hadm_id hadm
         ON hadm.event_trace_id = src.trace_id
         AND hadm.row_num = 1
 ;

--- a/etl/etl/lk_meas_unit.sql
+++ b/etl/etl/lk_meas_unit.sql
@@ -23,12 +23,12 @@
 -- lk_meas_operator_concept
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_operator_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_operator_concept AS
 SELECT
     vc.concept_name     AS source_code, -- operator_name,
     vc.concept_id       AS target_concept_id -- operator_concept_id
 FROM
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
 WHERE
     vc.domain_id = 'Meas Value Operator'
 ;
@@ -37,7 +37,7 @@ WHERE
 -- tmp_meas_unit
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.tmp_meas_unit AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.tmp_meas_unit AS
 SELECT
     vc.concept_code                         AS concept_code,
     vc.vocabulary_id                        AS vocabulary_id,
@@ -48,7 +48,7 @@ SELECT
         ORDER BY UPPER(vc.vocabulary_id)
     )                                       AS row_num -- for de-duplication
 FROM
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
 WHERE
     -- gcpt_lab_unit_to_concept -> mimiciv_meas_unit
     vc.vocabulary_id IN ('UCUM', 'mimiciv_meas_unit', 'mimiciv_meas_wf_unit')
@@ -59,7 +59,7 @@ WHERE
 -- lk_meas_unit_concept
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_unit_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_unit_concept AS
 SELECT
     vc.concept_code         AS source_code,
     vc.vocabulary_id        AS source_vocabulary_id,
@@ -68,13 +68,13 @@ SELECT
     vc2.domain_id           AS target_domain_id,
     vc2.concept_id          AS target_concept_id
 FROM
-    `@etl_project`.@etl_dataset.tmp_meas_unit vc
+    @etl_project.@etl_dataset.tmp_meas_unit vc
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         -- AND vc2.standard_concept = 'S' -- units like beats/min are allowed to be non-standard
         AND vc2.invalid_reason IS NULL
@@ -82,4 +82,4 @@ WHERE
     vc.row_num = 1
 ;
 
-DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.tmp_meas_unit;
+DROP TABLE IF EXISTS @etl_project.@etl_dataset.tmp_meas_unit;

--- a/etl/etl/lk_meas_waveform.sql
+++ b/etl/etl/lk_meas_waveform.sql
@@ -69,9 +69,9 @@
 
 -- poc_2
 
-DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.lk_wf_clean;
+DROP TABLE IF EXISTS @etl_project.@etl_dataset.lk_wf_clean;
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_waveform_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_waveform_clean AS
 SELECT
     wh.subject_id                           AS subject_id,
     CONCAT(
@@ -93,18 +93,18 @@ SELECT
     src.load_row_id                         AS load_row_id,
     src.trace_id                            AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_waveform_mx src -- wm
+    @etl_project.@etl_dataset.src_waveform_mx src -- wm
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_waveform_header wh
+    @etl_project.@etl_dataset.src_waveform_header wh
         ON wh.reference_id = src.reference_id
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_patients pat
+    @etl_project.@etl_dataset.src_patients pat
         ON wh.subject_id = pat.subject_id
 ;
 
 -- poc_3
 
-INSERT INTO `@etl_project`.@etl_dataset.lk_waveform_clean
+INSERT INTO @etl_project.@etl_dataset.lk_waveform_clean
 SELECT
     wh.subject_id                           AS subject_id,
     CONCAT(
@@ -126,9 +126,9 @@ SELECT
     src.load_row_id                         AS load_row_id,
     src.trace_id                            AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_waveform_mx_3 src -- wm
+    @etl_project.@etl_dataset.src_waveform_mx_3 src -- wm
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_waveform_header_3 wh
+    @etl_project.@etl_dataset.src_waveform_header_3 wh
         ON wh.case_id = src.case_id
 ;
 
@@ -138,7 +138,7 @@ INNER JOIN
 -- row_num is added to select the earliest if more than one hadm_ids are found
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_wf_hadm_id AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_wf_hadm_id AS
 SELECT
     src.trace_id                        AS event_trace_id,
     adm.hadm_id                         AS hadm_id,
@@ -147,9 +147,9 @@ SELECT
         ORDER BY adm.start_datetime
     )                                   AS row_num
 FROM
-    `@etl_project`.@etl_dataset.lk_waveform_clean src
+    @etl_project.@etl_dataset.lk_waveform_clean src
 INNER JOIN 
-    `@etl_project`.@etl_dataset.lk_admissions_clean adm
+    @etl_project.@etl_dataset.lk_admissions_clean adm
         ON adm.subject_id = src.subject_id
         AND src.start_datetime BETWEEN adm.start_datetime AND adm.end_datetime
 ;
@@ -161,7 +161,7 @@ INNER JOIN
 -- -------------------------------------------------------------------
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_meas_waveform_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_meas_waveform_mapped AS
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())       AS measurement_id,
     src.subject_id                          AS subject_id,
@@ -182,29 +182,29 @@ SELECT
     src.load_row_id                         AS load_row_id,
     src.trace_id                            AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_waveform_clean src
+    @etl_project.@etl_dataset.lk_waveform_clean src
 -- mapping of the main source code
 -- mapping for measurement unit
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_meas_unit_concept uc
+    @etl_project.@etl_dataset.lk_meas_unit_concept uc
         ON uc.source_code = src.unit_source_value
         -- supposing that the standard mapping is supplemented with custom concepts for waveform specific units
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc1
+    @etl_project.@etl_dataset.voc_concept vc1
         ON vc1.concept_code = src.source_code
         AND vc1.vocabulary_id = 'mimiciv_meas_wf'
             -- supposing that the standard mapping is supplemented with custom concepts for waveform specific values
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vr
+    @etl_project.@etl_dataset.voc_concept_relationship vr
         ON vc1.concept_id = vr.concept_id_1
         AND vr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.lk_wf_hadm_id hadm
+    @etl_project.@etl_dataset.lk_wf_hadm_id hadm
         ON hadm.event_trace_id = src.trace_id
         AND hadm.row_num = 1
 ;

--- a/etl/etl/lk_observation.sql
+++ b/etl/etl/lk_observation.sql
@@ -33,7 +33,7 @@
 -- rules 1-3
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_observation_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_observation_clean AS
 -- rule 1, insurance
 SELECT
     src.subject_id                  AS subject_id,
@@ -49,7 +49,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_admissions src -- adm
+    @etl_project.@etl_dataset.src_admissions src -- adm
 WHERE
     src.insurance IS NOT NULL
 
@@ -69,7 +69,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_admissions src -- adm
+    @etl_project.@etl_dataset.src_admissions src -- adm
 WHERE
     src.marital_status IS NOT NULL
 
@@ -89,7 +89,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_admissions src -- adm
+    @etl_project.@etl_dataset.src_admissions src -- adm
 WHERE
     src.language IS NOT NULL
 ;
@@ -99,7 +99,7 @@ WHERE
 -- Rule 4, drgcodes
 -- -------------------------------------------------------------------
 
-INSERT INTO `@etl_project`.@etl_dataset.lk_observation_clean
+INSERT INTO @etl_project.@etl_dataset.lk_observation_clean
 SELECT
     src.subject_id                  AS subject_id,
     src.hadm_id                     AS hadm_id,
@@ -115,9 +115,9 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_drgcodes src -- drg
+    @etl_project.@etl_dataset.src_drgcodes src -- drg
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_admissions adm
+    @etl_project.@etl_dataset.src_admissions adm
         ON src.hadm_id = adm.hadm_id
 WHERE
     src.description IS NOT NULL
@@ -130,7 +130,7 @@ WHERE
 -- Rules 1-4
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_obs_admissions_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_obs_admissions_concept AS
 SELECT DISTINCT
     src.value_as_string         AS source_code,
     src.source_vocabulary_id    AS source_vocabulary_id,
@@ -139,19 +139,19 @@ SELECT DISTINCT
     vc2.domain_id               AS target_domain_id,
     vc2.concept_id              AS target_concept_id
 FROM
-    `@etl_project`.@etl_dataset.lk_observation_clean src
+    @etl_project.@etl_dataset.lk_observation_clean src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON src.value_as_string = vc.concept_code
         AND src.source_vocabulary_id = vc.vocabulary_id
         -- valid period should be used to map drg_code, but due to the date shift it is not applicable
         -- AND src.start_datetime BETWEEN vc.valid_start_date AND vc.valid_end_date
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL
@@ -161,7 +161,7 @@ LEFT JOIN
 -- lk_observation_mapped
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_observation_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_observation_mapped AS
 SELECT
     src.hadm_id                             AS hadm_id, -- to visit
     src.subject_id                          AS subject_id, -- to person
@@ -179,9 +179,9 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_observation_clean src
+    @etl_project.@etl_dataset.lk_observation_clean src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_obs_admissions_concept lc
+    @etl_project.@etl_dataset.lk_obs_admissions_concept lc
         ON src.value_as_string = lc.source_code
         AND src.source_vocabulary_id = lc.source_vocabulary_id
 ;

--- a/etl/etl/lk_procedure.sql
+++ b/etl/etl/lk_procedure.sql
@@ -28,16 +28,16 @@
 -- -------------------------------------------------------------------
 
 
-DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.lk_datetimeevents_concept;
-DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.lk_proc_event_clean;
-DROP TABLE IF EXISTS `@etl_project`.@etl_dataset.lk_datetimeevents_clean;
+DROP TABLE IF EXISTS @etl_project.@etl_dataset.lk_datetimeevents_concept;
+DROP TABLE IF EXISTS @etl_project.@etl_dataset.lk_proc_event_clean;
+DROP TABLE IF EXISTS @etl_project.@etl_dataset.lk_datetimeevents_clean;
 
 -- -------------------------------------------------------------------
 -- lk_hcpcsevents_clean
 -- Rule 1, HCPCS mapping
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_hcpcsevents_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_hcpcsevents_clean AS
  SELECT
     src.subject_id      AS subject_id,
     src.hadm_id         AS hadm_id,
@@ -50,9 +50,9 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_hcpcsevents_clean AS
     src.load_row_id                     AS load_row_id,
     src.trace_id                        AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_hcpcsevents src
+    @etl_project.@etl_dataset.src_hcpcsevents src
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_admissions adm
+    @etl_project.@etl_dataset.src_admissions adm
         ON src.hadm_id = adm.hadm_id
 ;
 
@@ -61,7 +61,7 @@ INNER JOIN
 -- Rule 2, ICD mapping
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_procedures_icd_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_procedures_icd_clean AS
 SELECT
     src.subject_id                              AS subject_id,
     src.hadm_id                                 AS hadm_id,
@@ -79,9 +79,9 @@ SELECT
     src.load_row_id                     AS load_row_id,
     src.trace_id                        AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_procedures_icd src
+    @etl_project.@etl_dataset.src_procedures_icd src
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_admissions adm
+    @etl_project.@etl_dataset.src_admissions adm
         ON src.hadm_id = adm.hadm_id
 ;
 
@@ -90,7 +90,7 @@ INNER JOIN
 -- Rule 3, d_items custom mapping
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_proc_d_items_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_proc_d_items_clean AS
 SELECT
     src.subject_id                      AS subject_id,
     src.hadm_id                         AS hadm_id,
@@ -104,7 +104,7 @@ SELECT
     src.load_row_id                     AS load_row_id,
     src.trace_id                        AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_procedureevents src
+    @etl_project.@etl_dataset.src_procedureevents src
 WHERE
     src.cancelreason = 0 -- not cancelled
 ;
@@ -115,7 +115,7 @@ WHERE
 -- gcpt_datetimeevents_to_concept -> mimiciv_proc_datetimeevents
 -- filter out 55 rows where the year is earlier than one year before patient's birth
 -- -------------------------------------------------------------------
-INSERT INTO `@etl_project`.@etl_dataset.lk_proc_d_items_clean
+INSERT INTO @etl_project.@etl_dataset.lk_proc_d_items_clean
 SELECT
     src.subject_id                      AS subject_id,
     src.hadm_id                         AS hadm_id,
@@ -128,9 +128,9 @@ SELECT
     src.load_row_id                     AS load_row_id,
     src.trace_id                        AS trace_id    
 FROM
-    `@etl_project`.@etl_dataset.src_datetimeevents src -- de
+    @etl_project.@etl_dataset.src_datetimeevents src -- de
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_patients pat
+    @etl_project.@etl_dataset.src_patients pat
         ON  pat.subject_id = src.subject_id
 WHERE
     EXTRACT(YEAR FROM src.value) >= pat.anchor_year - pat.anchor_age - 1
@@ -143,7 +143,7 @@ WHERE
 -- add gcpt_cpt4_to_concept --> mimiciv_proc_xxx (?)
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_hcpcs_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_hcpcs_concept AS
 SELECT
     vc.concept_code         AS source_code,
     vc.vocabulary_id        AS source_vocabulary_id,    
@@ -152,13 +152,13 @@ SELECT
     vc2.domain_id           AS target_domain_id,
     vc2.concept_id          AS target_concept_id
 FROM
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL
@@ -171,7 +171,7 @@ WHERE
 -- ICD - Rule 2
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_icd_proc_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_icd_proc_concept AS
 SELECT
     REPLACE(vc.concept_code, '.', '')       AS source_code,
     vc.vocabulary_id                        AS source_vocabulary_id,
@@ -180,13 +180,13 @@ SELECT
     vc2.domain_id                           AS target_domain_id,
     vc2.concept_id                          AS target_concept_id
 FROM
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL
@@ -203,7 +203,7 @@ WHERE
 -- can be optimized by including Specimen mapping to lk_itemid_concept
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_itemid_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_itemid_concept AS
 SELECT
     d_items.itemid                      AS itemid,
     CAST(d_items.itemid AS STRING)      AS source_code,
@@ -214,20 +214,20 @@ SELECT
     vc2.domain_id                       AS target_domain_id,
     vc2.concept_id                      AS target_concept_id
 FROM
-    `@etl_project`.@etl_dataset.src_d_items d_items
+    @etl_project.@etl_dataset.src_d_items d_items
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON vc.concept_code = CAST(d_items.itemid AS STRING)
         AND vc.vocabulary_id IN (
             'mimiciv_proc_itemid',
             'mimiciv_proc_datetimeevents'
         )
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1
         AND vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL
@@ -244,7 +244,7 @@ WHERE
 
 -- Rule 1, HCPCS
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_procedure_mapped AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_procedure_mapped AS
 SELECT
     src.subject_id                          AS subject_id, -- to person
     src.hadm_id                             AS hadm_id, -- to visit
@@ -265,15 +265,15 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_hcpcsevents_clean src
+    @etl_project.@etl_dataset.lk_hcpcsevents_clean src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_hcpcs_concept lc
+    @etl_project.@etl_dataset.lk_hcpcs_concept lc
         ON src.hcpcs_cd = lc.source_code
 ;
 
 -- Rule 2, ICD
 
-INSERT INTO `@etl_project`.@etl_dataset.lk_procedure_mapped
+INSERT INTO @etl_project.@etl_dataset.lk_procedure_mapped
 SELECT
     src.subject_id                          AS subject_id, -- to person
     src.hadm_id                             AS hadm_id, -- to visit
@@ -294,9 +294,9 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_procedures_icd_clean src
+    @etl_project.@etl_dataset.lk_procedures_icd_clean src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_icd_proc_concept lc
+    @etl_project.@etl_dataset.lk_icd_proc_concept lc
         ON  src.source_code = lc.source_code
         AND src.source_vocabulary_id = lc.source_vocabulary_id
 ;
@@ -304,7 +304,7 @@ LEFT JOIN
 -- rule 3, "procedureevents" and itemid custom mapping
 -- rule 4, "datetimeevents" and itemid custom mapping
 
-INSERT INTO `@etl_project`.@etl_dataset.lk_procedure_mapped
+INSERT INTO @etl_project.@etl_dataset.lk_procedure_mapped
 SELECT
     src.subject_id                          AS subject_id, -- to person
     src.hadm_id                             AS hadm_id, -- to visit
@@ -325,9 +325,9 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_proc_d_items_clean src
+    @etl_project.@etl_dataset.lk_proc_d_items_clean src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_itemid_concept lc
+    @etl_project.@etl_dataset.lk_itemid_concept lc
         ON src.itemid = lc.itemid
 ;
 

--- a/etl/etl/lk_vis_part_1.sql
+++ b/etl/etl/lk_vis_part_1.sql
@@ -26,7 +26,7 @@
 -- ER admissions to visit_detail too
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_admissions_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_admissions_clean AS
 SELECT
     src.subject_id                                  AS subject_id,
     src.hadm_id                                     AS hadm_id,
@@ -44,7 +44,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.src_admissions src -- adm
+    @etl_project.@etl_dataset.src_admissions src -- adm
 ;
 
 -- -------------------------------------------------------------------
@@ -54,7 +54,7 @@ FROM
 -- from transfers without discharges to visit_detail
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_transfers_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_transfers_clean AS
 SELECT
     src.subject_id                                  AS subject_id,
     COALESCE(src.hadm_id, vis.hadm_id)              AS hadm_id,
@@ -69,9 +69,9 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.src_transfers src
+    @etl_project.@etl_dataset.src_transfers src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_admissions_clean vis -- associate transfers with admissions according to 
+    @etl_project.@etl_dataset.lk_admissions_clean vis -- associate transfers with admissions according to 
         ON vis.subject_id = src.subject_id
         AND src.intime BETWEEN vis.start_datetime AND vis.end_datetime
         AND src.hadm_id IS NULL
@@ -86,18 +86,18 @@ WHERE
 -- SERVICES information
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_services_duplicated AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_services_duplicated AS
 SELECT
     trace_id, COUNT(*) AS row_count
 FROM 
-    `@etl_project`.@etl_dataset.src_services src
+    @etl_project.@etl_dataset.src_services src
 GROUP BY
     src.trace_id
 HAVING COUNT(*) > 1
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_services_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_services_clean AS
 SELECT
     src.subject_id                                  AS subject_id,
     src.hadm_id                                     AS hadm_id,
@@ -119,9 +119,9 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.src_services src
+    @etl_project.@etl_dataset.src_services src
 LEFT JOIN
-    `@etl_project`.@etl_dataset.lk_services_duplicated sd
+    @etl_project.@etl_dataset.lk_services_duplicated sd
         ON src.trace_id = sd.trace_id
 WHERE
     sd.trace_id IS NULL -- remove duplicates with the exact same time of transferring

--- a/etl/etl/lk_vis_part_2.sql
+++ b/etl/etl/lk_vis_part_2.sql
@@ -31,7 +31,7 @@
 --      lk_meas_waveform_mapped
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_visit_no_hadm_all AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_visit_no_hadm_all AS
 -- labevents
 SELECT
     src.subject_id                                  AS subject_id,
@@ -43,7 +43,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_labevents_mapped src
+    @etl_project.@etl_dataset.lk_meas_labevents_mapped src
 WHERE
     src.hadm_id IS NULL
 UNION ALL
@@ -58,7 +58,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_specimen_mapped src
+    @etl_project.@etl_dataset.lk_specimen_mapped src
 WHERE
     src.hadm_id IS NULL
 UNION ALL
@@ -73,7 +73,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_organism_mapped src
+    @etl_project.@etl_dataset.lk_meas_organism_mapped src
 WHERE
     src.hadm_id IS NULL
 UNION ALL
@@ -88,7 +88,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_ab_mapped src
+    @etl_project.@etl_dataset.lk_meas_ab_mapped src
 WHERE
     src.hadm_id IS NULL
 UNION ALL
@@ -103,7 +103,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_waveform_mapped src
+    @etl_project.@etl_dataset.lk_meas_waveform_mapped src
 WHERE
     src.hadm_id IS NULL
 ;
@@ -112,7 +112,7 @@ WHERE
 -- lk_visit_no_hadm_dist
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_visit_no_hadm_dist AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_visit_no_hadm_dist AS
 SELECT
     src.subject_id                                  AS subject_id,
     src.date_id                                     AS date_id,
@@ -130,7 +130,7 @@ SELECT
         src.date_id AS date_id
     ))                                  AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_visit_no_hadm_all src
+    @etl_project.@etl_dataset.lk_visit_no_hadm_all src
 GROUP BY
     src.subject_id,
     src.date_id
@@ -144,7 +144,7 @@ GROUP BY
 --      lk_meas_waveform_mapped
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_visit_detail_waveform_dist AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_visit_detail_waveform_dist AS
 SELECT
     src.subject_id                                  AS subject_id,
     src.hadm_id                                     AS hadm_id,
@@ -163,7 +163,7 @@ SELECT
         src.reference_id AS reference_id
     ))                                  AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_meas_waveform_mapped src
+    @etl_project.@etl_dataset.lk_meas_waveform_mapped src
 GROUP BY
     src.subject_id,
     src.hadm_id,
@@ -174,7 +174,7 @@ GROUP BY
 -- lk_visit_clean
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_visit_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_visit_clean AS
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())               AS visit_occurrence_id,
     src.subject_id                                  AS subject_id,
@@ -195,7 +195,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_admissions_clean src -- adm
+    @etl_project.@etl_dataset.lk_admissions_clean src -- adm
 UNION ALL
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())               AS visit_occurrence_id,
@@ -217,7 +217,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM
-    `@etl_project`.@etl_dataset.lk_visit_no_hadm_dist src -- adm
+    @etl_project.@etl_dataset.lk_visit_no_hadm_dist src -- adm
 ;
 
 -- -------------------------------------------------------------------
@@ -227,7 +227,7 @@ FROM
 -- transfers with valid hadm_id
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_visit_detail_clean AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_visit_detail_clean AS
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())               AS visit_detail_id,
     src.subject_id                                  AS subject_id,
@@ -247,7 +247,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.lk_transfers_clean src
+    @etl_project.@etl_dataset.lk_transfers_clean src
 WHERE
     src.hadm_id IS NOT NULL -- some ER transfers are excluded because not all of them fit to additional single day visits
 ;
@@ -258,7 +258,7 @@ WHERE
 -- Rule 2.
 -- ER admissions
 -- -------------------------------------------------------------------
-INSERT INTO `@etl_project`.@etl_dataset.lk_visit_detail_clean
+INSERT INTO @etl_project.@etl_dataset.lk_visit_detail_clean
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())               AS visit_detail_id,
     src.subject_id                                  AS subject_id,
@@ -277,7 +277,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.lk_admissions_clean src
+    @etl_project.@etl_dataset.lk_admissions_clean src
 WHERE
     src.is_er_admission
 ;
@@ -288,7 +288,7 @@ WHERE
 -- Rule 3.
 -- services
 -- -------------------------------------------------------------------
-INSERT INTO `@etl_project`.@etl_dataset.lk_visit_detail_clean
+INSERT INTO @etl_project.@etl_dataset.lk_visit_detail_clean
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())               AS visit_detail_id,
     src.subject_id                                  AS subject_id,
@@ -308,7 +308,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.lk_services_clean src
+    @etl_project.@etl_dataset.lk_services_clean src
 WHERE
     src.prev_service = src.lag_service -- ensure that the services sequence is still consistent after removing duplicates
 ;
@@ -319,7 +319,7 @@ WHERE
 -- Rule 4.
 -- waveforms
 -- -------------------------------------------------------------------
-INSERT INTO `@etl_project`.@etl_dataset.lk_visit_detail_clean
+INSERT INTO @etl_project.@etl_dataset.lk_visit_detail_clean
 SELECT
     FARM_FINGERPRINT(GENERATE_UUID())               AS visit_detail_id,
     src.subject_id                                  AS subject_id,
@@ -335,7 +335,7 @@ SELECT
     src.load_row_id                 AS load_row_id,
     src.trace_id                    AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.lk_visit_detail_waveform_dist src
+    @etl_project.@etl_dataset.lk_visit_detail_waveform_dist src
 ;
 
 -- -------------------------------------------------------------------
@@ -343,7 +343,7 @@ FROM
 -- skip "mapped"
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_visit_detail_prev_next AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_visit_detail_prev_next AS
 SELECT 
     src.visit_detail_id                             AS visit_detail_id,
     src.subject_id                                  AS subject_id,
@@ -385,9 +385,9 @@ SELECT
     src.load_row_id                   AS load_row_id,
     src.trace_id                      AS trace_id
 FROM 
-    `@etl_project`.@etl_dataset.lk_visit_detail_clean src
+    @etl_project.@etl_dataset.lk_visit_detail_clean src
 LEFT JOIN 
-    `@etl_project`.@etl_dataset.lk_visit_clean vis
+    @etl_project.@etl_dataset.lk_visit_clean vis
         ON  src.subject_id = vis.subject_id
         AND (
             src.hadm_id = vis.hadm_id
@@ -409,20 +409,20 @@ LEFT JOIN
 -- then map it to standard Visit concepts
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.lk_visit_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.lk_visit_concept AS
 SELECT 
     vc.concept_code     AS source_code,
     vc.concept_id       AS source_concept_id,
     vc2.concept_id      AS target_concept_id,
     vc.vocabulary_id    AS source_vocabulary_id
 FROM 
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept_relationship vcr
+    @etl_project.@etl_dataset.voc_concept_relationship vcr
         ON  vc.concept_id = vcr.concept_id_1 
         and vcr.relationship_id = 'Maps to'
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc2
+    @etl_project.@etl_dataset.voc_concept vc2
         ON vc2.concept_id = vcr.concept_id_2
         AND vc2.standard_concept = 'S'
         AND vc2.invalid_reason IS NULL

--- a/etl/staging/st_core.sql
+++ b/etl/staging/st_core.sql
@@ -20,7 +20,7 @@
 -- src_patients
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_patients AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_patients AS
 SELECT 
     subject_id                          AS subject_id,
     anchor_year                         AS anchor_year,
@@ -34,14 +34,14 @@ SELECT
         subject_id AS subject_id
     ))                                  AS trace_id
 FROM
-    `@source_project`.@core_dataset.patients
+    @source_project.@core_dataset.patients
 ;
 
 -- -------------------------------------------------------------------
 -- src_admissions
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_admissions AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_admissions AS
 SELECT
     hadm_id                             AS hadm_id, -- PK
     subject_id                          AS subject_id,
@@ -66,14 +66,14 @@ SELECT
         hadm_id AS hadm_id
     ))                                  AS trace_id
 FROM
-    `@source_project`.@core_dataset.admissions
+    @source_project.@core_dataset.admissions
 ;
 
 -- -------------------------------------------------------------------
 -- src_transfers
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_transfers AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_transfers AS
 SELECT
     transfer_id                         AS transfer_id,
     hadm_id                             AS hadm_id,
@@ -91,6 +91,6 @@ SELECT
         transfer_id AS transfer_id
     ))                                  AS trace_id
 FROM
-    `@source_project`.@core_dataset.transfers
+    @source_project.@core_dataset.transfers
 ;
 

--- a/etl/staging/st_hosp.sql
+++ b/etl/staging/st_hosp.sql
@@ -23,7 +23,7 @@
 -- src_diagnoses_icd
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_diagnoses_icd AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_diagnoses_icd AS
 SELECT
     subject_id      AS subject_id,
     hadm_id         AS hadm_id,
@@ -38,7 +38,7 @@ SELECT
         seq_num AS seq_num
     ))                                  AS trace_id
 FROM
-    `@source_project`.@hosp_dataset.diagnoses_icd
+    @source_project.@hosp_dataset.diagnoses_icd
 ;
 
 -- -------------------------------------------------------------------
@@ -49,7 +49,7 @@ FROM
 -- src_services
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_services AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_services AS
 SELECT
     subject_id                          AS subject_id,
     hadm_id                             AS hadm_id,
@@ -65,14 +65,14 @@ SELECT
         transfertime AS transfertime
     ))                                  AS trace_id
 FROM
-    `@source_project`.@hosp_dataset.services
+    @source_project.@hosp_dataset.services
 ;
 
 -- -------------------------------------------------------------------
 -- src_labevents
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_labevents AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_labevents AS
 SELECT
     labevent_id                         AS labevent_id,
     subject_id                          AS subject_id,
@@ -91,14 +91,14 @@ SELECT
         labevent_id AS labevent_id
     ))                                  AS trace_id
 FROM
-    `@source_project`.@hosp_dataset.labevents
+    @source_project.@hosp_dataset.labevents
 ;
 
 -- -------------------------------------------------------------------
 -- src_d_labitems
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_d_labitems AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_d_labitems AS
 SELECT
     itemid                              AS itemid,
     label                               AS label,
@@ -112,7 +112,7 @@ SELECT
         itemid AS itemid
     ))                                  AS trace_id
 FROM
-    `@source_project`.@hosp_dataset.d_labitems
+    @source_project.@hosp_dataset.d_labitems
 ;
 
 
@@ -124,7 +124,7 @@ FROM
 -- src_procedures_icd
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_procedures_icd AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_procedures_icd AS
 SELECT
     subject_id                          AS subject_id,
     hadm_id                             AS hadm_id,
@@ -140,14 +140,14 @@ SELECT
         icd_version AS icd_version
     ))                                  AS trace_id -- this set of fields is not unique. To set quantity?
 FROM
-    `@source_project`.@hosp_dataset.procedures_icd
+    @source_project.@hosp_dataset.procedures_icd
 ;
 
 -- -------------------------------------------------------------------
 -- src_hcpcsevents
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_hcpcsevents AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_hcpcsevents AS
 SELECT
     hadm_id                             AS hadm_id,
     subject_id                          AS subject_id,
@@ -164,7 +164,7 @@ SELECT
         seq_num AS seq_num
     ))                                  AS trace_id -- this set of fields is not unique. To set quantity?
 FROM
-    `@source_project`.@hosp_dataset.hcpcsevents
+    @source_project.@hosp_dataset.hcpcsevents
 ;
 
 
@@ -172,7 +172,7 @@ FROM
 -- src_drgcodes
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_drgcodes AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_drgcodes AS
 SELECT
     hadm_id                             AS hadm_id,
     subject_id                          AS subject_id,
@@ -187,14 +187,14 @@ SELECT
         COALESCE(drg_code, '') AS drg_code
     ))                                  AS trace_id -- this set of fields is not unique.
 FROM
-    `@source_project`.@hosp_dataset.drgcodes
+    @source_project.@hosp_dataset.drgcodes
 ;
 
 -- -------------------------------------------------------------------
 -- src_prescriptions
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_prescriptions AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_prescriptions AS
 SELECT
     hadm_id                             AS hadm_id,
     subject_id                          AS subject_id,
@@ -223,7 +223,7 @@ SELECT
         starttime AS starttime
     ))                                  AS trace_id
 FROM
-    `@source_project`.@hosp_dataset.prescriptions
+    @source_project.@hosp_dataset.prescriptions
 ;
 
 
@@ -231,7 +231,7 @@ FROM
 -- src_microbiologyevents
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_microbiologyevents AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_microbiologyevents AS
 SELECT
     microevent_id               AS microevent_id,
     subject_id                  AS subject_id,
@@ -258,7 +258,7 @@ SELECT
         microevent_id AS microevent_id
     ))                                  AS trace_id
 FROM
-    `@source_project`.@hosp_dataset.microbiologyevents
+    @source_project.@hosp_dataset.microbiologyevents
 ;
 
 -- -------------------------------------------------------------------
@@ -266,7 +266,7 @@ FROM
 -- raw d_micro is no longer available both in mimic_hosp and mimiciv_hosp
 -- -------------------------------------------------------------------
 
--- CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_d_micro AS
+-- CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_d_micro AS
 -- SELECT
 --     itemid                      AS itemid, -- numeric ID
 --     label                       AS label, -- source_code for custom mapping
@@ -278,7 +278,7 @@ FROM
 --         itemid AS itemid
 --     ))                                  AS trace_id
 -- FROM
---     `@source_project`.@hosp_dataset.d_micro
+--     @source_project.@hosp_dataset.d_micro
 -- ;
 
 -- -------------------------------------------------------------------
@@ -286,7 +286,7 @@ FROM
 -- MIMIC IV 2.0: generate src_d_micro from microbiologyevents
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_d_micro AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_d_micro AS
 WITH d_micro AS (
 
     SELECT DISTINCT
@@ -299,7 +299,7 @@ WITH d_micro AS (
             ab_itemid AS itemid
         ))                                  AS trace_id
     FROM
-        `@source_project`.@hosp_dataset.microbiologyevents
+        @source_project.@hosp_dataset.microbiologyevents
     WHERE
         ab_itemid IS NOT NULL
     UNION ALL
@@ -313,7 +313,7 @@ WITH d_micro AS (
             test_itemid AS itemid
         ))                                  AS trace_id
     FROM
-        `@source_project`.@hosp_dataset.microbiologyevents
+        @source_project.@hosp_dataset.microbiologyevents
     WHERE
         test_itemid IS NOT NULL
     UNION ALL
@@ -327,7 +327,7 @@ WITH d_micro AS (
             org_itemid AS itemid
         ))                                  AS trace_id
     FROM
-        `@source_project`.@hosp_dataset.microbiologyevents
+        @source_project.@hosp_dataset.microbiologyevents
     WHERE
         org_itemid IS NOT NULL
     UNION ALL
@@ -341,7 +341,7 @@ WITH d_micro AS (
             spec_itemid AS itemid
         ))                                  AS trace_id
     FROM
-        `@source_project`.@hosp_dataset.microbiologyevents
+        @source_project.@hosp_dataset.microbiologyevents
     WHERE
         spec_itemid IS NOT NULL
 )
@@ -361,7 +361,7 @@ FROM
 -- src_pharmacy
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_pharmacy AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_pharmacy AS
 SELECT
     pharmacy_id                         AS pharmacy_id,
     medication                          AS medication,
@@ -377,6 +377,6 @@ SELECT
         pharmacy_id AS pharmacy_id
     ))                                  AS trace_id
 FROM
-    `@source_project`.@hosp_dataset.pharmacy
+    @source_project.@hosp_dataset.pharmacy
 ;
 

--- a/etl/staging/st_icu.sql
+++ b/etl/staging/st_icu.sql
@@ -18,7 +18,7 @@
 -- src_procedureevents
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_procedureevents AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_procedureevents AS
 SELECT
     hadm_id                             AS hadm_id,
     subject_id                          AS subject_id,
@@ -36,14 +36,14 @@ SELECT
         starttime AS starttime
     ))                                  AS trace_id
 FROM
-    `@source_project`.@icu_dataset.procedureevents
+    @source_project.@icu_dataset.procedureevents
 ;
 
 -- -------------------------------------------------------------------
 -- src_d_items
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_d_items AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_d_items AS
 SELECT
     itemid                              AS itemid,
     label                               AS label,
@@ -62,14 +62,14 @@ SELECT
         linksto AS linksto
     ))                                  AS trace_id
 FROM
-    `@source_project`.@icu_dataset.d_items
+    @source_project.@icu_dataset.d_items
 ;
 
 -- -------------------------------------------------------------------
 -- src_datetimeevents
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_datetimeevents AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_datetimeevents AS
 SELECT
     subject_id  AS subject_id,
     hadm_id     AS hadm_id,
@@ -87,11 +87,11 @@ SELECT
         charttime AS charttime
     ))                                  AS trace_id
 FROM
-    `@source_project`.@icu_dataset.datetimeevents
+    @source_project.@icu_dataset.datetimeevents
 ;
 
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_chartevents AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_chartevents AS
 SELECT
     subject_id  AS subject_id,
     hadm_id     AS hadm_id,
@@ -111,5 +111,5 @@ SELECT
         charttime AS charttime
     ))                                  AS trace_id
 FROM
-    `@source_project`.@icu_dataset.chartevents
+    @source_project.@icu_dataset.chartevents
 ;

--- a/etl/staging/st_waveform_poc_1.sql
+++ b/etl/staging/st_waveform_poc_1.sql
@@ -61,7 +61,7 @@
 -- src_waveform_header
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_header
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_waveform_header
 (       
     reference_id            STRING,
     raw_files_path          STRING,
@@ -82,7 +82,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_header
 -- src_waveform_header
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_dx
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_waveform_dx
 (       
     reference_id            STRING,  -- FK to the header
     waveform_id             STRING,  -- row number inside the reference_id
@@ -102,7 +102,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_dx
 
 -- parsed codes to be targeted to table cdm_measurement
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_mx
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_waveform_mx
 (
     subject_id              INT64,
     reference_id            STRING,  -- FK to the header
@@ -141,12 +141,12 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_mx
 
 -- select random existing subject_id and hadm_id
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_subject AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_waveform_subject AS
 SELECT
     subject_id,
     hadm_id
 FROM
-    `@etl_project`.@etl_dataset.src_admissions
+    @etl_project.@etl_dataset.src_admissions
 LIMIT 1
 ;
 
@@ -155,7 +155,7 @@ LIMIT 1
 -- -------------------------------------------------------------------
 
 
-INSERT INTO `@etl_project`.@etl_dataset.src_waveform_header
+INSERT INTO @etl_project.@etl_dataset.src_waveform_header
 SELECT
     '3700002_0011.CCSIMxv1' AS reference_id,
     'gs://waveform_storage/3700002/0011.wfdb' AS raw_files_path,
@@ -170,14 +170,14 @@ SELECT
 FROM
 (
     SELECT COUNT(*) AS row_count 
-    FROM `@wf_project`.@wf_dataset.raw_case055_ecg_lines3
+    FROM @wf_project.@wf_dataset.raw_case055_ecg_lines3
 ) src
 CROSS JOIN
-    `@etl_project`.@etl_dataset.src_waveform_subject subj
+    @etl_project.@etl_dataset.src_waveform_subject subj
 ;
 
 -- line_1
-INSERT INTO `@etl_project`.@etl_dataset.src_waveform_mx
+INSERT INTO @etl_project.@etl_dataset.src_waveform_mx
 -- line_1
 SELECT
     subj.subject_id AS subject_id,
@@ -197,9 +197,9 @@ SELECT
             src.row_id AS row_id
         )) AS trace_id -- 
 FROM
-    `@wf_project`.@wf_dataset.raw_case055_ecg_lines3 src
+    @wf_project.@wf_dataset.raw_case055_ecg_lines3 src
 CROSS JOIN
-    `@etl_project`.@etl_dataset.src_waveform_subject subj
+    @etl_project.@etl_dataset.src_waveform_subject subj
 UNION ALL
 -- line_2
 SELECT
@@ -220,9 +220,9 @@ SELECT
             src.row_id AS row_id
         )) AS trace_id -- 
 FROM
-    `@wf_project`.@wf_dataset.raw_case055_ecg_lines3 src
+    @wf_project.@wf_dataset.raw_case055_ecg_lines3 src
 CROSS JOIN
-    `@etl_project`.@etl_dataset.src_waveform_subject subj
+    @etl_project.@etl_dataset.src_waveform_subject subj
 UNION ALL
 -- line_3
 SELECT
@@ -243,7 +243,7 @@ SELECT
             src.row_id AS row_id
         )) AS trace_id -- 
 FROM
-    `@wf_project`.@wf_dataset.raw_case055_ecg_lines3 src
+    @wf_project.@wf_dataset.raw_case055_ecg_lines3 src
 CROSS JOIN
-    `@etl_project`.@etl_dataset.src_waveform_subject subj
+    @etl_project.@etl_dataset.src_waveform_subject subj
 ;

--- a/etl/staging/st_waveform_poc_2.sql
+++ b/etl/staging/st_waveform_poc_2.sql
@@ -61,7 +61,7 @@
 -- src_waveform_header
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_header
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_waveform_header
 (       
     reference_id            STRING,
     raw_files_path          STRING,
@@ -77,7 +77,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_header
 
 -- parsed codes to be targeted to table cdm_measurement
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_mx
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_waveform_mx
 (
     case_id                 INT64,  -- FK to the header
     segment_name            STRING, -- two digits of case_id, 5 digits of internal sequence number
@@ -109,7 +109,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_mx
 -- -------------------------------------------------------------------
 
 
-INSERT INTO `@etl_project`.@etl_dataset.src_waveform_header
+INSERT INTO @etl_project.@etl_dataset.src_waveform_header
 SELECT
     subj.short_reference_id             AS reference_id,
     subj.long_reference_id              AS raw_files_path,
@@ -125,21 +125,21 @@ SELECT
         subj.short_reference_id AS reference_id
     ))                                  AS trace_id
 FROM
-    `@wf_project`.@wf_dataset.wf_header subj
+    @wf_project.@wf_dataset.wf_header subj
 INNER JOIN
     (
         SELECT 
             case_id, 
             MIN(date_time) AS start_datetime,
             MAX(date_time) AS end_datetime 
-        FROM `@wf_project`.@wf_dataset.wf_details
+        FROM @wf_project.@wf_dataset.wf_details
         GROUP BY case_id
     ) src
         ON src.case_id = subj.case_id
 ;
 
 
-INSERT INTO `@etl_project`.@etl_dataset.src_waveform_mx
+INSERT INTO @etl_project.@etl_dataset.src_waveform_mx
 SELECT
     src.case_id                         AS case_id, -- FK to the header
     CAST(src.segment_name AS STRING)    AS segment_name,
@@ -158,8 +158,8 @@ SELECT
             src.src_name AS src_name
         )) AS trace_id -- 
 FROM
-    `@wf_project`.@wf_dataset.wf_details src
+    @wf_project.@wf_dataset.wf_details src
 INNER JOIN
-    `@wf_project`.@wf_dataset.wf_header subj
+    @wf_project.@wf_dataset.wf_header subj
         ON src.case_id = subj.case_id
 ;

--- a/etl/staging/st_waveform_poc_3.sql
+++ b/etl/staging/st_waveform_poc_3.sql
@@ -34,7 +34,7 @@
 -- src_waveform_header
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_header_3
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_waveform_header_3
 (       
     reference_id            STRING,
     raw_files_path          STRING,
@@ -50,7 +50,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_header_3
 
 -- parsed codes to be targeted to table cdm_measurement
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_mx_3
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.src_waveform_mx_3
 (
     case_id                 STRING,  -- FK to the header
     segment_name            STRING, -- two digits of case_id, 5 digits of internal sequence number
@@ -86,7 +86,7 @@ CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.src_waveform_mx_3
 -- -------------------------------------------------------------------
 
 
-INSERT INTO `@etl_project`.@etl_dataset.src_waveform_header_3
+INSERT INTO @etl_project.@etl_dataset.src_waveform_header_3
 SELECT
     subj.short_reference_id             AS reference_id,
     subj.long_reference_id              AS raw_files_path,
@@ -102,13 +102,13 @@ SELECT
         subj.short_reference_id AS reference_id
     ))                                  AS trace_id
 FROM
-    `@wf_project`.@wf_dataset.poc_3_header subj
+    @wf_project.@wf_dataset.poc_3_header subj
 ;
 
 -- Chunk 1
 -- 25-second interval, mass data
 
-INSERT INTO `@etl_project`.@etl_dataset.src_waveform_mx_3
+INSERT INTO @etl_project.@etl_dataset.src_waveform_mx_3
 SELECT
     src.case_id                         AS case_id, -- FK to the header
     src.segment_name                    AS segment_name,
@@ -131,9 +131,9 @@ SELECT
             src.src_name AS src_name
         )) AS trace_id -- 
 FROM
-    `@wf_project`.@wf_dataset.poc_3_chunk_1 src
+    @wf_project.@wf_dataset.poc_3_chunk_1 src
 INNER JOIN
-    `@etl_project`.@etl_dataset.src_patients pat
+    @etl_project.@etl_dataset.src_patients pat
         ON  CAST(REPLACE(src.case_id, 'p', '') AS INT64) = pat.subject_id    -- filter out mass data in demo dataset
 ;
 
@@ -141,7 +141,7 @@ INNER JOIN
 -- Chunk 2
 -- 5-minute interval, summarized data for Full set and Demo
 
-INSERT INTO `@etl_project`.@etl_dataset.src_waveform_mx_3
+INSERT INTO @etl_project.@etl_dataset.src_waveform_mx_3
 SELECT
     src.case_id                         AS case_id, -- FK to the header
     src.segment_name                    AS segment_name,
@@ -164,14 +164,14 @@ SELECT
             src.src_name AS src_name
         )) AS trace_id -- 
 FROM
-    `@wf_project`.@wf_dataset.poc_3_chunk_2 src
+    @wf_project.@wf_dataset.poc_3_chunk_2 src
 ;
 
 
 -- Chunk 3
 -- 25-second interval, tiny mass data for Demo
 
-INSERT INTO `@etl_project`.@etl_dataset.src_waveform_mx_3
+INSERT INTO @etl_project.@etl_dataset.src_waveform_mx_3
 SELECT
     src.case_id                         AS case_id, -- FK to the header
     src.segment_name                    AS segment_name,
@@ -194,7 +194,7 @@ SELECT
             src.src_name AS src_name
         )) AS trace_id -- 
 FROM
-    `@wf_project`.@wf_dataset.poc_3_chunk_3 src
+    @wf_project.@wf_dataset.poc_3_chunk_3 src
 ;
 
 

--- a/etl/staging/voc_copy_to_target_dataset.sql
+++ b/etl/staging/voc_copy_to_target_dataset.sql
@@ -11,41 +11,41 @@
 -- check
 -- SELECT 'VOC', COUNT(*) FROM `@voc_project`.@voc_dataset.concept
 -- UNION ALL
--- SELECT 'TARGET', COUNT(*) FROM `@etl_project`.@etl_dataset.voc_concept
+-- SELECT 'TARGET', COUNT(*) FROM @etl_project.@etl_dataset.voc_concept
 -- ;
 
 -- affected by custom mapping
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept AS
 SELECT * FROM `@voc_project`.@voc_dataset.concept
 ;
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_relationship AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept_relationship AS
 SELECT * FROM `@voc_project`.@voc_dataset.concept_relationship
 ;
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_vocabulary AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_vocabulary AS
 SELECT * FROM `@voc_project`.@voc_dataset.vocabulary
 ;
 
 -- not affected by custom mapping
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_domain AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_domain AS
 SELECT * FROM `@voc_project`.@voc_dataset.domain
 ;
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_class AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept_class AS
 SELECT * FROM `@voc_project`.@voc_dataset.concept_class
 ;
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_relationship AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_relationship AS
 SELECT * FROM `@voc_project`.@voc_dataset.relationship
 ;
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_synonym AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept_synonym AS
 SELECT * FROM `@voc_project`.@voc_dataset.concept_synonym
 ;
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_concept_ancestor AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_concept_ancestor AS
 SELECT * FROM `@voc_project`.@voc_dataset.concept_ancestor
 ;
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.voc_drug_strength AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_drug_strength AS
 SELECT * FROM `@voc_project`.@voc_dataset.drug_strength
 ;
 

--- a/etl/unload/unload_to_atlas_2b_concepts.sql
+++ b/etl/unload/unload_to_atlas_2b_concepts.sql
@@ -1,6 +1,6 @@
 -- Unload to ATLAS-- 2 billion concepts from Vocabulary tables
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.2b_concept AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.2b_concept AS 
 SELECT
     concept_id,
     concept_name,
@@ -12,12 +12,12 @@ SELECT
     valid_start_DATE,
     valid_end_DATE,
     invalid_reason
-FROM `@etl_project`.@etl_dataset.voc_concept
+FROM @etl_project.@etl_dataset.voc_concept
 WHERE
     concept_id >= 2000000000
 ;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.2b_concept_relationship AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.2b_concept_relationship AS 
 SELECT
     concept_id_1,
     concept_id_2,
@@ -25,20 +25,20 @@ SELECT
     valid_start_DATE,
     valid_end_DATE,
     invalid_reason
-FROM `@etl_project`.@etl_dataset.voc_concept_relationship
+FROM @etl_project.@etl_dataset.voc_concept_relationship
 WHERE
     concept_id_1 >= 2000000000
     OR concept_id_2 >= 2000000000
 ;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.2b_vocabulary AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.2b_vocabulary AS 
 SELECT
     vocabulary_id,
     vocabulary_name,
     vocabulary_reference,
     vocabulary_version,
     vocabulary_concept_id
-FROM `@etl_project`.@etl_dataset.voc_vocabulary
+FROM @etl_project.@etl_dataset.voc_vocabulary
 WHERE
     vocabulary_concept_id >= 2000000000
 ;

--- a/etl/unload/unload_to_atlas_extra.sql
+++ b/etl/unload/unload_to_atlas_extra.sql
@@ -1,21 +1,21 @@
 -- Unload to ATLAS
 -- extra tables (d_items to concept)
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.d_items_to_concept AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.d_items_to_concept AS 
 SELECT
     *
-FROM `@etl_project`.@etl_dataset.d_items_to_concept
+FROM @etl_project.@etl_dataset.d_items_to_concept
 ;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.d_labitems_to_concept AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.d_labitems_to_concept AS 
 SELECT
     *
-FROM `@etl_project`.@etl_dataset.d_labitems_to_concept
+FROM @etl_project.@etl_dataset.d_labitems_to_concept
 ;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.d_micro_to_concept AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.d_micro_to_concept AS 
 SELECT
     *
-FROM `@etl_project`.@etl_dataset.d_micro_to_concept
+FROM @etl_project.@etl_dataset.d_micro_to_concept
 ;
 

--- a/etl/unload/unload_to_atlas_gen.sql
+++ b/etl/unload/unload_to_atlas_gen.sql
@@ -2,7 +2,7 @@
 
 -- Unload to ATLAS-- Copy Vocabulary tables
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.concept AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.concept AS 
 SELECT
     concept_id,
     concept_name,
@@ -14,32 +14,32 @@ SELECT
     valid_start_DATE,
     valid_end_DATE,
     invalid_reason
-FROM `@etl_project`.@etl_dataset.voc_concept;
+FROM @etl_project.@etl_dataset.voc_concept;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.vocabulary AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.vocabulary AS 
 SELECT
     vocabulary_id,
     vocabulary_name,
     vocabulary_reference,
     vocabulary_version,
     vocabulary_concept_id
-FROM `@etl_project`.@etl_dataset.voc_vocabulary;
+FROM @etl_project.@etl_dataset.voc_vocabulary;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.domain AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.domain AS 
 SELECT
     domain_id,
     domain_name,
     domain_concept_id
-FROM `@etl_project`.@etl_dataset.voc_domain;
+FROM @etl_project.@etl_dataset.voc_domain;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.concept_class AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.concept_class AS 
 SELECT
     concept_class_id,
     concept_class_name,
     concept_class_concept_id
-FROM `@etl_project`.@etl_dataset.voc_concept_class;
+FROM @etl_project.@etl_dataset.voc_concept_class;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.concept_relationship AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.concept_relationship AS 
 SELECT
     concept_id_1,
     concept_id_2,
@@ -47,9 +47,9 @@ SELECT
     valid_start_DATE,
     valid_end_DATE,
     invalid_reason
-FROM `@etl_project`.@etl_dataset.voc_concept_relationship;
+FROM @etl_project.@etl_dataset.voc_concept_relationship;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.relationship AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.relationship AS 
 SELECT
     relationship_id,
     relationship_name,
@@ -57,24 +57,24 @@ SELECT
     defines_ancestry,
     reverse_relationship_id,
     relationship_concept_id
-FROM `@etl_project`.@etl_dataset.voc_relationship;
+FROM @etl_project.@etl_dataset.voc_relationship;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.concept_synonym AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.concept_synonym AS 
 SELECT
     concept_id,
     concept_synonym_name,
     language_concept_id
-FROM `@etl_project`.@etl_dataset.voc_concept_synonym;
+FROM @etl_project.@etl_dataset.voc_concept_synonym;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.concept_ancestor AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.concept_ancestor AS 
 SELECT
     ancestor_concept_id,
     descendant_concept_id,
     min_levels_of_separation,
     max_levels_of_separation
-FROM `@etl_project`.@etl_dataset.voc_concept_ancestor;
+FROM @etl_project.@etl_dataset.voc_concept_ancestor;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.source_to_concept_map AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.source_to_concept_map AS 
 SELECT
     source_code,
     source_concept_id,
@@ -85,9 +85,9 @@ SELECT
     valid_start_DATE,
     valid_end_DATE,
     invalid_reason
-FROM `@etl_project`.@etl_dataset.voc_source_to_concept_map;
+FROM @etl_project.@etl_dataset.voc_source_to_concept_map;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.drug_strength AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.drug_strength AS 
 SELECT
     drug_concept_id,
     ingredient_concept_id,
@@ -101,12 +101,12 @@ SELECT
     valid_start_DATE,
     valid_end_DATE,
     invalid_reason
-FROM `@etl_project`.@etl_dataset.voc_drug_strength;
+FROM @etl_project.@etl_dataset.voc_drug_strength;
 
 
 -- Copy CDM tables
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.cohort_definition AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.cohort_definition AS 
 SELECT
     cohort_definition_id,
     cohort_definition_name,
@@ -115,18 +115,18 @@ SELECT
     cohort_definition_syntax,
     subject_concept_id,
     cohort_initiation_date
-FROM `@etl_project`.@etl_dataset.cdm_cohort_definition;
+FROM @etl_project.@etl_dataset.cdm_cohort_definition;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.attribute_definition AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.attribute_definition AS 
 SELECT
     attribute_definition_id,
     attribute_name,
     attribute_description,
     attribute_type_concept_id,
     attribute_syntax
-FROM `@etl_project`.@etl_dataset.cdm_attribute_definition;
+FROM @etl_project.@etl_dataset.cdm_attribute_definition;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.cdm_source AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.cdm_source AS 
 SELECT
     cdm_source_name,
     cdm_source_abbreviation,
@@ -138,9 +138,9 @@ SELECT
     cdm_release_date,
     cdm_version,
     vocabulary_version
-FROM `@etl_project`.@etl_dataset.cdm_cdm_source;
+FROM @etl_project.@etl_dataset.cdm_cdm_source;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.metadata AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.metadata AS 
 SELECT
     metadata_concept_id,
     metadata_type_concept_id,
@@ -149,9 +149,9 @@ SELECT
     value_as_concept_id,
     metadata_date,
     metadata_datetime
-FROM `@etl_project`.@etl_dataset.cdm_metadata;
+FROM @etl_project.@etl_dataset.cdm_metadata;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.person AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.person AS 
 SELECT
     person_id,
     gender_concept_id,
@@ -171,18 +171,18 @@ SELECT
     race_source_concept_id,
     ethnicity_source_value,
     ethnicity_source_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_person;
+FROM @etl_project.@etl_dataset.cdm_person;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.observation_period AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.observation_period AS 
 SELECT
     observation_period_id,
     person_id,
     observation_period_start_date,
     observation_period_end_date,
     period_type_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_observation_period;
+FROM @etl_project.@etl_dataset.cdm_observation_period;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.specimen AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.specimen AS 
 SELECT
     specimen_id,
     person_id,
@@ -199,9 +199,9 @@ SELECT
     unit_source_value,
     anatomic_site_source_value,
     disease_status_source_value
-FROM `@etl_project`.@etl_dataset.cdm_specimen;
+FROM @etl_project.@etl_dataset.cdm_specimen;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.death AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.death AS 
 SELECT
     person_id,
     death_date,
@@ -210,9 +210,9 @@ SELECT
     cause_concept_id,
     cause_source_value,
     cause_source_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_death;
+FROM @etl_project.@etl_dataset.cdm_death;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.visit_occurrence AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.visit_occurrence AS 
 SELECT
     visit_occurrence_id,
     person_id,
@@ -231,9 +231,9 @@ SELECT
     discharge_to_concept_id,
     discharge_to_source_value,
     preceding_visit_occurrence_id
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence;
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.visit_detail AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.visit_detail AS 
 SELECT
     visit_detail_id,
     person_id,
@@ -254,9 +254,9 @@ SELECT
     discharge_to_source_value,
     visit_detail_parent_id,
     visit_occurrence_id
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail;
+FROM @etl_project.@etl_dataset.cdm_visit_detail;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.procedure_occurrence AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.procedure_occurrence AS 
 SELECT
     procedure_occurrence_id,
     person_id,
@@ -272,9 +272,9 @@ SELECT
     procedure_source_value,
     procedure_source_concept_id,
     modifier_source_value
-FROM `@etl_project`.@etl_dataset.cdm_procedure_occurrence;
+FROM @etl_project.@etl_dataset.cdm_procedure_occurrence;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.drug_exposure AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.drug_exposure AS 
 SELECT
     drug_exposure_id,
     person_id,
@@ -299,9 +299,9 @@ SELECT
     drug_source_concept_id,
     route_source_value,
     dose_unit_source_value
-FROM `@etl_project`.@etl_dataset.cdm_drug_exposure;
+FROM @etl_project.@etl_dataset.cdm_drug_exposure;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.device_exposure AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.device_exposure AS 
 SELECT
     device_exposure_id,
     person_id,
@@ -318,9 +318,9 @@ SELECT
     visit_detail_id,
     device_source_value,
     device_source_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_device_exposure;
+FROM @etl_project.@etl_dataset.cdm_device_exposure;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.condition_occurrence AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.condition_occurrence AS 
 SELECT
     condition_occurrence_id,
     person_id,
@@ -338,9 +338,9 @@ SELECT
     condition_source_concept_id,
     condition_status_source_value,
     condition_status_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_condition_occurrence;
+FROM @etl_project.@etl_dataset.cdm_condition_occurrence;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.measurement AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.measurement AS 
 SELECT
     measurement_id,
     person_id,
@@ -362,9 +362,9 @@ SELECT
     measurement_source_concept_id,
     unit_source_value,
     value_source_value
-FROM `@etl_project`.@etl_dataset.cdm_measurement;
+FROM @etl_project.@etl_dataset.cdm_measurement;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.note AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.note AS 
 SELECT
     note_id,
     person_id,
@@ -380,9 +380,9 @@ SELECT
     visit_occurrence_id,
     visit_detail_id,
     note_source_value
-FROM `@etl_project`.@etl_dataset.cdm_note;
+FROM @etl_project.@etl_dataset.cdm_note;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.note_nlp AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.note_nlp AS 
 SELECT
     note_nlp_id,
     note_id,
@@ -398,9 +398,9 @@ SELECT
     term_exists,
     term_temporal,
     term_modifiers
-FROM `@etl_project`.@etl_dataset.cdm_note_nlp;
+FROM @etl_project.@etl_dataset.cdm_note_nlp;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.observation AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.observation AS 
 SELECT
     observation_id,
     person_id,
@@ -420,18 +420,18 @@ SELECT
     observation_source_concept_id,
     unit_source_value,
     qualifier_source_value
-FROM `@etl_project`.@etl_dataset.cdm_observation;
+FROM @etl_project.@etl_dataset.cdm_observation;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.fact_relationship AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.fact_relationship AS 
 SELECT
     domain_concept_id_1,
     fact_id_1,
     domain_concept_id_2,
     fact_id_2,
     relationship_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_fact_relationship;
+FROM @etl_project.@etl_dataset.cdm_fact_relationship;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.location AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.location AS 
 SELECT
     location_id,
     address_1,
@@ -441,9 +441,9 @@ SELECT
     zip,
     county,
     location_source_value
-FROM `@etl_project`.@etl_dataset.cdm_location;
+FROM @etl_project.@etl_dataset.cdm_location;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.care_site AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.care_site AS 
 SELECT
     care_site_id,
     care_site_name,
@@ -451,9 +451,9 @@ SELECT
     location_id,
     care_site_source_value,
     place_of_service_source_value
-FROM `@etl_project`.@etl_dataset.cdm_care_site;
+FROM @etl_project.@etl_dataset.cdm_care_site;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.provider AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.provider AS 
 SELECT
     provider_id,
     provider_name,
@@ -468,9 +468,9 @@ SELECT
     specialty_source_concept_id,
     gender_source_value,
     gender_source_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_provider;
+FROM @etl_project.@etl_dataset.cdm_provider;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.payer_plan_period AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.payer_plan_period AS 
 SELECT
     payer_plan_period_id,
     person_id,
@@ -489,9 +489,9 @@ SELECT
     stop_reason_concept_id,
     stop_reason_source_value,
     stop_reason_source_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period;
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.cost AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.cost AS 
 SELECT
     cost_id,
     cost_event_id,
@@ -515,17 +515,17 @@ SELECT
     revenue_code_source_value,
     drg_concept_id,
     drg_source_value
-FROM `@etl_project`.@etl_dataset.cdm_cost;
+FROM @etl_project.@etl_dataset.cdm_cost;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.cohort AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.cohort AS 
 SELECT
     cohort_definition_id,
     subject_id,
     cohort_start_date,
     cohort_end_date
-FROM `@etl_project`.@etl_dataset.cdm_cohort;
+FROM @etl_project.@etl_dataset.cdm_cohort;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.cohort_attribute AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.cohort_attribute AS 
 SELECT
     cohort_definition_id,
     subject_id,
@@ -534,9 +534,9 @@ SELECT
     attribute_definition_id,
     value_as_number,
     value_as_concept_id
-FROM `@etl_project`.@etl_dataset.cdm_cohort_attribute;
+FROM @etl_project.@etl_dataset.cdm_cohort_attribute;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.drug_era AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.drug_era AS 
 SELECT
     drug_era_id,
     person_id,
@@ -545,9 +545,9 @@ SELECT
     drug_era_end_date,
     drug_exposure_count,
     gap_days
-FROM `@etl_project`.@etl_dataset.cdm_drug_era;
+FROM @etl_project.@etl_dataset.cdm_drug_era;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.dose_era AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.dose_era AS 
 SELECT
     dose_era_id,
     person_id,
@@ -556,9 +556,9 @@ SELECT
     dose_value,
     dose_era_start_date,
     dose_era_end_date
-FROM `@etl_project`.@etl_dataset.cdm_dose_era;
+FROM @etl_project.@etl_dataset.cdm_dose_era;
 
-CREATE OR REPLACE TABLE `@atlas_project`.@atlas_dataset.condition_era AS 
+CREATE OR REPLACE TABLE @atlas_project.@atlas_dataset.condition_era AS 
 SELECT
     condition_era_id,
     person_id,
@@ -566,5 +566,5 @@ SELECT
     condition_era_start_date,
     condition_era_end_date,
     condition_occurrence_count
-FROM `@etl_project`.@etl_dataset.cdm_condition_era;
+FROM @etl_project.@etl_dataset.cdm_condition_era;
 

--- a/test/metrics_gen/me_mapping_rate_from_conf.bak.sql
+++ b/test/metrics_gen/me_mapping_rate_from_conf.bak.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_mapping_rate;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_mapping_rate
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_mapping_rate;
+CREATE TABLE @metrics_project.@metrics_dataset.me_mapping_rate
 (
     table_name        STRING,
     concept_field     STRING,
@@ -8,7 +8,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_mapping_rate
     total             INT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_care_site'        AS table_name,
     'place_of_service_concept_id'     AS concept_field,
@@ -17,11 +17,11 @@ SELECT
         ROUND(CAST(COUNT(IF(place_of_service_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_care_site ev
+FROM @etl_project.@etl_dataset.cdm_care_site ev
 WHERE place_of_service_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_provider'        AS table_name,
     'specialty_concept_id'     AS concept_field,
@@ -30,11 +30,11 @@ SELECT
         ROUND(CAST(COUNT(IF(specialty_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_provider ev
+FROM @etl_project.@etl_dataset.cdm_provider ev
 WHERE specialty_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_provider'        AS table_name,
     'gender_concept_id'     AS concept_field,
@@ -43,11 +43,11 @@ SELECT
         ROUND(CAST(COUNT(IF(gender_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_provider ev
+FROM @etl_project.@etl_dataset.cdm_provider ev
 WHERE gender_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_person'        AS table_name,
     'gender_concept_id'     AS concept_field,
@@ -56,11 +56,11 @@ SELECT
         ROUND(CAST(COUNT(IF(gender_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_person ev
+FROM @etl_project.@etl_dataset.cdm_person ev
 WHERE gender_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_person'        AS table_name,
     'race_concept_id'     AS concept_field,
@@ -69,11 +69,11 @@ SELECT
         ROUND(CAST(COUNT(IF(race_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_person ev
+FROM @etl_project.@etl_dataset.cdm_person ev
 WHERE race_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_person'        AS table_name,
     'ethnicity_concept_id'     AS concept_field,
@@ -82,11 +82,11 @@ SELECT
         ROUND(CAST(COUNT(IF(ethnicity_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_person ev
+FROM @etl_project.@etl_dataset.cdm_person ev
 WHERE ethnicity_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_death'        AS table_name,
     'death_type_concept_id'     AS concept_field,
@@ -95,11 +95,11 @@ SELECT
         ROUND(CAST(COUNT(IF(death_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_death ev
+FROM @etl_project.@etl_dataset.cdm_death ev
 WHERE death_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_death'        AS table_name,
     'cause_concept_id'     AS concept_field,
@@ -108,11 +108,11 @@ SELECT
         ROUND(CAST(COUNT(IF(cause_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_death ev
+FROM @etl_project.@etl_dataset.cdm_death ev
 WHERE cause_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation_period'        AS table_name,
     'period_type_concept_id'     AS concept_field,
@@ -121,11 +121,11 @@ SELECT
         ROUND(CAST(COUNT(IF(period_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation_period ev
+FROM @etl_project.@etl_dataset.cdm_observation_period ev
 WHERE period_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_payer_plan_period'        AS table_name,
     'payer_concept_id'     AS concept_field,
@@ -134,11 +134,11 @@ SELECT
         ROUND(CAST(COUNT(IF(payer_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period ev
 WHERE payer_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_payer_plan_period'        AS table_name,
     'plan_concept_id'     AS concept_field,
@@ -147,11 +147,11 @@ SELECT
         ROUND(CAST(COUNT(IF(plan_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period ev
 WHERE plan_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_payer_plan_period'        AS table_name,
     'sponsor_concept_id'     AS concept_field,
@@ -160,11 +160,11 @@ SELECT
         ROUND(CAST(COUNT(IF(sponsor_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period ev
 WHERE sponsor_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_payer_plan_period'        AS table_name,
     'stop_reason_concept_id'     AS concept_field,
@@ -173,11 +173,11 @@ SELECT
         ROUND(CAST(COUNT(IF(stop_reason_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period ev
 WHERE stop_reason_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'visit_concept_id'     AS concept_field,
@@ -186,11 +186,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE visit_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'visit_type_concept_id'     AS concept_field,
@@ -199,11 +199,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE visit_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'visit_source_concept_id'     AS concept_field,
@@ -212,11 +212,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_source_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE visit_source_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'admitting_source_concept_id'     AS concept_field,
@@ -225,11 +225,11 @@ SELECT
         ROUND(CAST(COUNT(IF(admitting_source_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE admitting_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'discharge_to_concept_id'     AS concept_field,
@@ -238,11 +238,11 @@ SELECT
         ROUND(CAST(COUNT(IF(discharge_to_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE discharge_to_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'visit_detail_concept_id'     AS concept_field,
@@ -251,11 +251,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_detail_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE visit_detail_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'visit_detail_type_concept_id'     AS concept_field,
@@ -264,11 +264,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_detail_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE visit_detail_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'visit_detail_source_concept_id'     AS concept_field,
@@ -277,11 +277,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_detail_source_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE visit_detail_source_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'admitting_source_concept_id'     AS concept_field,
@@ -290,11 +290,11 @@ SELECT
         ROUND(CAST(COUNT(IF(admitting_source_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE admitting_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'discharge_to_concept_id'     AS concept_field,
@@ -303,11 +303,11 @@ SELECT
         ROUND(CAST(COUNT(IF(discharge_to_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE discharge_to_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_condition_occurrence'        AS table_name,
     'condition_concept_id'     AS concept_field,
@@ -316,11 +316,11 @@ SELECT
         ROUND(CAST(COUNT(IF(condition_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_condition_occurrence ev
 WHERE condition_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_condition_occurrence'        AS table_name,
     'condition_type_concept_id'     AS concept_field,
@@ -329,11 +329,11 @@ SELECT
         ROUND(CAST(COUNT(IF(condition_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_condition_occurrence ev
 WHERE condition_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_condition_occurrence'        AS table_name,
     'condition_status_concept_id'     AS concept_field,
@@ -342,11 +342,11 @@ SELECT
         ROUND(CAST(COUNT(IF(condition_status_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_condition_occurrence ev
 WHERE condition_status_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_procedure_occurrence'        AS table_name,
     'procedure_concept_id'     AS concept_field,
@@ -355,11 +355,11 @@ SELECT
         ROUND(CAST(COUNT(IF(procedure_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_procedure_occurrence ev
 WHERE procedure_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_procedure_occurrence'        AS table_name,
     'procedure_type_concept_id'     AS concept_field,
@@ -368,11 +368,11 @@ SELECT
         ROUND(CAST(COUNT(IF(procedure_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_procedure_occurrence ev
 WHERE procedure_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_procedure_occurrence'        AS table_name,
     'modifier_concept_id'     AS concept_field,
@@ -381,11 +381,11 @@ SELECT
         ROUND(CAST(COUNT(IF(modifier_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_procedure_occurrence ev
 WHERE modifier_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'observation_concept_id'     AS concept_field,
@@ -394,11 +394,11 @@ SELECT
         ROUND(CAST(COUNT(IF(observation_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE observation_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'observation_type_concept_id'     AS concept_field,
@@ -407,11 +407,11 @@ SELECT
         ROUND(CAST(COUNT(IF(observation_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE observation_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'value_as_concept_id'     AS concept_field,
@@ -420,11 +420,11 @@ SELECT
         ROUND(CAST(COUNT(IF(value_as_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE value_as_string IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'qualifier_concept_id'     AS concept_field,
@@ -433,11 +433,11 @@ SELECT
         ROUND(CAST(COUNT(IF(qualifier_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE qualifier_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'unit_concept_id'     AS concept_field,
@@ -446,11 +446,11 @@ SELECT
         ROUND(CAST(COUNT(IF(unit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE unit_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'measurement_concept_id'     AS concept_field,
@@ -459,11 +459,11 @@ SELECT
         ROUND(CAST(COUNT(IF(measurement_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE measurement_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'measurement_type_concept_id'     AS concept_field,
@@ -472,11 +472,11 @@ SELECT
         ROUND(CAST(COUNT(IF(measurement_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE measurement_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'operator_concept_id'     AS concept_field,
@@ -485,11 +485,11 @@ SELECT
         ROUND(CAST(COUNT(IF(operator_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE operator_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'value_as_concept_id'     AS concept_field,
@@ -498,11 +498,11 @@ SELECT
         ROUND(CAST(COUNT(IF(value_as_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE value_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'unit_concept_id'     AS concept_field,
@@ -511,11 +511,11 @@ SELECT
         ROUND(CAST(COUNT(IF(unit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE unit_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_device_exposure'        AS table_name,
     'device_concept_id'     AS concept_field,
@@ -524,11 +524,11 @@ SELECT
         ROUND(CAST(COUNT(IF(device_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_device_exposure ev
+FROM @etl_project.@etl_dataset.cdm_device_exposure ev
 WHERE device_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_device_exposure'        AS table_name,
     'device_type_concept_id'     AS concept_field,
@@ -537,11 +537,11 @@ SELECT
         ROUND(CAST(COUNT(IF(device_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_device_exposure ev
+FROM @etl_project.@etl_dataset.cdm_device_exposure ev
 WHERE device_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_drug_exposure'        AS table_name,
     'drug_concept_id'     AS concept_field,
@@ -550,11 +550,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drug_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_drug_exposure ev
+FROM @etl_project.@etl_dataset.cdm_drug_exposure ev
 WHERE drug_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_drug_exposure'        AS table_name,
     'drug_type_concept_id'     AS concept_field,
@@ -563,11 +563,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drug_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_drug_exposure ev
+FROM @etl_project.@etl_dataset.cdm_drug_exposure ev
 WHERE drug_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_drug_exposure'        AS table_name,
     'route_concept_id'     AS concept_field,
@@ -576,11 +576,11 @@ SELECT
         ROUND(CAST(COUNT(IF(route_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_drug_exposure ev
+FROM @etl_project.@etl_dataset.cdm_drug_exposure ev
 WHERE route_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cost'        AS table_name,
     'cost_type_concept_id'     AS concept_field,
@@ -589,11 +589,11 @@ SELECT
         ROUND(CAST(COUNT(IF(cost_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cost ev
+FROM @etl_project.@etl_dataset.cdm_cost ev
 WHERE cost_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cost'        AS table_name,
     'currency_concept_id'     AS concept_field,
@@ -602,11 +602,11 @@ SELECT
         ROUND(CAST(COUNT(IF(currency_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cost ev
+FROM @etl_project.@etl_dataset.cdm_cost ev
 WHERE currency_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cost'        AS table_name,
     'revenue_code_concept_id'     AS concept_field,
@@ -615,11 +615,11 @@ SELECT
         ROUND(CAST(COUNT(IF(revenue_code_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cost ev
+FROM @etl_project.@etl_dataset.cdm_cost ev
 WHERE revenue_code_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cost'        AS table_name,
     'drg_concept_id'     AS concept_field,
@@ -628,11 +628,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drg_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cost ev
+FROM @etl_project.@etl_dataset.cdm_cost ev
 WHERE drg_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_condition_era'        AS table_name,
     'condition_concept_id'     AS concept_field,
@@ -641,11 +641,11 @@ SELECT
         ROUND(CAST(COUNT(IF(condition_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_condition_era ev
+FROM @etl_project.@etl_dataset.cdm_condition_era ev
 WHERE condition_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_drug_era'        AS table_name,
     'drug_concept_id'     AS concept_field,
@@ -654,11 +654,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drug_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_drug_era ev
+FROM @etl_project.@etl_dataset.cdm_drug_era ev
 WHERE drug_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_dose_era'        AS table_name,
     'drug_concept_id'     AS concept_field,
@@ -667,11 +667,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drug_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_dose_era ev
+FROM @etl_project.@etl_dataset.cdm_dose_era ev
 WHERE drug_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_dose_era'        AS table_name,
     'unit_concept_id'     AS concept_field,
@@ -680,11 +680,11 @@ SELECT
         ROUND(CAST(COUNT(IF(unit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_dose_era ev
+FROM @etl_project.@etl_dataset.cdm_dose_era ev
 WHERE unit_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'specimen_concept_id'     AS concept_field,
@@ -693,11 +693,11 @@ SELECT
         ROUND(CAST(COUNT(IF(specimen_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE specimen_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'specimen_type_concept_id'     AS concept_field,
@@ -706,11 +706,11 @@ SELECT
         ROUND(CAST(COUNT(IF(specimen_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE specimen_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'unit_concept_id'     AS concept_field,
@@ -719,11 +719,11 @@ SELECT
         ROUND(CAST(COUNT(IF(unit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE unit_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'anatomic_site_concept_id'     AS concept_field,
@@ -732,11 +732,11 @@ SELECT
         ROUND(CAST(COUNT(IF(anatomic_site_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE anatomic_site_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'disease_status_concept_id'     AS concept_field,
@@ -745,11 +745,11 @@ SELECT
         ROUND(CAST(COUNT(IF(disease_status_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE disease_status_source_value IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note'        AS table_name,
     'note_type_concept_id'     AS concept_field,
@@ -758,11 +758,11 @@ SELECT
         ROUND(CAST(COUNT(IF(note_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note ev
+FROM @etl_project.@etl_dataset.cdm_note ev
 WHERE note_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note'        AS table_name,
     'note_class_concept_id'     AS concept_field,
@@ -771,11 +771,11 @@ SELECT
         ROUND(CAST(COUNT(IF(note_class_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note ev
+FROM @etl_project.@etl_dataset.cdm_note ev
 WHERE note_class_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note'        AS table_name,
     'encoding_concept_id'     AS concept_field,
@@ -784,11 +784,11 @@ SELECT
         ROUND(CAST(COUNT(IF(encoding_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note ev
+FROM @etl_project.@etl_dataset.cdm_note ev
 WHERE encoding_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note'        AS table_name,
     'language_concept_id'     AS concept_field,
@@ -797,11 +797,11 @@ SELECT
         ROUND(CAST(COUNT(IF(language_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note ev
+FROM @etl_project.@etl_dataset.cdm_note ev
 WHERE language_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note_nlp'        AS table_name,
     'section_concept_id'     AS concept_field,
@@ -810,11 +810,11 @@ SELECT
         ROUND(CAST(COUNT(IF(section_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note_nlp ev
+FROM @etl_project.@etl_dataset.cdm_note_nlp ev
 WHERE section_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note_nlp'        AS table_name,
     'note_nlp_concept_id'     AS concept_field,
@@ -823,11 +823,11 @@ SELECT
         ROUND(CAST(COUNT(IF(note_nlp_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note_nlp ev
+FROM @etl_project.@etl_dataset.cdm_note_nlp ev
 WHERE note_nlp_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_fact_relationship'        AS table_name,
     'domain_concept_id_1'     AS concept_field,
@@ -836,11 +836,11 @@ SELECT
         ROUND(CAST(COUNT(IF(domain_concept_id_1 > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_fact_relationship ev
+FROM @etl_project.@etl_dataset.cdm_fact_relationship ev
 WHERE domain_concept_id_1 IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_fact_relationship'        AS table_name,
     'domain_concept_id_2'     AS concept_field,
@@ -849,11 +849,11 @@ SELECT
         ROUND(CAST(COUNT(IF(domain_concept_id_2 > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_fact_relationship ev
+FROM @etl_project.@etl_dataset.cdm_fact_relationship ev
 WHERE domain_concept_id_2 IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_fact_relationship'        AS table_name,
     'relationship_concept_id'     AS concept_field,
@@ -862,11 +862,11 @@ SELECT
         ROUND(CAST(COUNT(IF(relationship_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_fact_relationship ev
+FROM @etl_project.@etl_dataset.cdm_fact_relationship ev
 WHERE relationship_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cohort_attribute'        AS table_name,
     'value_as_concept_id'     AS concept_field,
@@ -875,11 +875,11 @@ SELECT
         ROUND(CAST(COUNT(IF(value_as_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cohort_attribute ev
+FROM @etl_project.@etl_dataset.cdm_cohort_attribute ev
 WHERE value_as_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_metadata'        AS table_name,
     'metadata_concept_id'     AS concept_field,
@@ -888,11 +888,11 @@ SELECT
         ROUND(CAST(COUNT(IF(metadata_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_metadata ev
+FROM @etl_project.@etl_dataset.cdm_metadata ev
 WHERE metadata_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_metadata'        AS table_name,
     'metadata_type_concept_id'     AS concept_field,
@@ -901,11 +901,11 @@ SELECT
         ROUND(CAST(COUNT(IF(metadata_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_metadata ev
+FROM @etl_project.@etl_dataset.cdm_metadata ev
 WHERE metadata_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_metadata'        AS table_name,
     'value_as_concept_id'     AS concept_field,
@@ -914,7 +914,7 @@ SELECT
         ROUND(CAST(COUNT(IF(value_as_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_metadata ev
+FROM @etl_project.@etl_dataset.cdm_metadata ev
 WHERE value_as_concept_id IS NOT NULL
 ;
 

--- a/test/metrics_gen/me_mapping_rate_from_conf.sql
+++ b/test/metrics_gen/me_mapping_rate_from_conf.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_mapping_rate;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_mapping_rate
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_mapping_rate;
+CREATE TABLE @metrics_project.@metrics_dataset.me_mapping_rate
 (
     table_name        STRING,
     concept_field     STRING,
@@ -8,7 +8,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_mapping_rate
     total             INT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_care_site'        AS table_name,
     'place_of_service_concept_id'     AS concept_field,
@@ -17,11 +17,11 @@ SELECT
         ROUND(CAST(COUNT(IF(place_of_service_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_care_site ev
+FROM @etl_project.@etl_dataset.cdm_care_site ev
 WHERE place_of_service_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_provider'        AS table_name,
     'specialty_concept_id'     AS concept_field,
@@ -30,11 +30,11 @@ SELECT
         ROUND(CAST(COUNT(IF(specialty_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_provider ev
+FROM @etl_project.@etl_dataset.cdm_provider ev
 WHERE specialty_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_provider'        AS table_name,
     'gender_concept_id'     AS concept_field,
@@ -43,11 +43,11 @@ SELECT
         ROUND(CAST(COUNT(IF(gender_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_provider ev
+FROM @etl_project.@etl_dataset.cdm_provider ev
 WHERE gender_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_person'        AS table_name,
     'gender_concept_id'     AS concept_field,
@@ -56,11 +56,11 @@ SELECT
         ROUND(CAST(COUNT(IF(gender_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_person ev
+FROM @etl_project.@etl_dataset.cdm_person ev
 WHERE gender_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_person'        AS table_name,
     'race_concept_id'     AS concept_field,
@@ -69,11 +69,11 @@ SELECT
         ROUND(CAST(COUNT(IF(race_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_person ev
+FROM @etl_project.@etl_dataset.cdm_person ev
 WHERE race_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_person'        AS table_name,
     'ethnicity_concept_id'     AS concept_field,
@@ -82,11 +82,11 @@ SELECT
         ROUND(CAST(COUNT(IF(ethnicity_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_person ev
+FROM @etl_project.@etl_dataset.cdm_person ev
 WHERE ethnicity_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_death'        AS table_name,
     'death_type_concept_id'     AS concept_field,
@@ -95,11 +95,11 @@ SELECT
         ROUND(CAST(COUNT(IF(death_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_death ev
+FROM @etl_project.@etl_dataset.cdm_death ev
 WHERE death_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_death'        AS table_name,
     'cause_concept_id'     AS concept_field,
@@ -108,11 +108,11 @@ SELECT
         ROUND(CAST(COUNT(IF(cause_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_death ev
+FROM @etl_project.@etl_dataset.cdm_death ev
 WHERE cause_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation_period'        AS table_name,
     'period_type_concept_id'     AS concept_field,
@@ -121,11 +121,11 @@ SELECT
         ROUND(CAST(COUNT(IF(period_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation_period ev
+FROM @etl_project.@etl_dataset.cdm_observation_period ev
 WHERE period_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_payer_plan_period'        AS table_name,
     'payer_concept_id'     AS concept_field,
@@ -134,11 +134,11 @@ SELECT
         ROUND(CAST(COUNT(IF(payer_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period ev
 WHERE payer_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_payer_plan_period'        AS table_name,
     'plan_concept_id'     AS concept_field,
@@ -147,11 +147,11 @@ SELECT
         ROUND(CAST(COUNT(IF(plan_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period ev
 WHERE plan_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_payer_plan_period'        AS table_name,
     'sponsor_concept_id'     AS concept_field,
@@ -160,11 +160,11 @@ SELECT
         ROUND(CAST(COUNT(IF(sponsor_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period ev
 WHERE sponsor_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_payer_plan_period'        AS table_name,
     'stop_reason_concept_id'     AS concept_field,
@@ -173,11 +173,11 @@ SELECT
         ROUND(CAST(COUNT(IF(stop_reason_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+FROM @etl_project.@etl_dataset.cdm_payer_plan_period ev
 WHERE stop_reason_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'visit_concept_id'     AS concept_field,
@@ -186,11 +186,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE visit_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'visit_type_concept_id'     AS concept_field,
@@ -199,11 +199,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE visit_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'visit_source_concept_id'     AS concept_field,
@@ -212,11 +212,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_source_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE visit_source_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'admitting_source_concept_id'     AS concept_field,
@@ -225,11 +225,11 @@ SELECT
         ROUND(CAST(COUNT(IF(admitting_source_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE admitting_source_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_occurrence'        AS table_name,
     'discharge_to_concept_id'     AS concept_field,
@@ -238,11 +238,11 @@ SELECT
         ROUND(CAST(COUNT(IF(discharge_to_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_visit_occurrence ev
 WHERE discharge_to_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'visit_detail_concept_id'     AS concept_field,
@@ -251,11 +251,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_detail_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE visit_detail_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'visit_detail_type_concept_id'     AS concept_field,
@@ -264,11 +264,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_detail_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE visit_detail_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'visit_detail_source_concept_id'     AS concept_field,
@@ -277,11 +277,11 @@ SELECT
         ROUND(CAST(COUNT(IF(visit_detail_source_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE visit_detail_source_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'admitting_source_concept_id'     AS concept_field,
@@ -290,11 +290,11 @@ SELECT
         ROUND(CAST(COUNT(IF(admitting_source_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE admitting_source_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_visit_detail'        AS table_name,
     'discharge_to_concept_id'     AS concept_field,
@@ -303,11 +303,11 @@ SELECT
         ROUND(CAST(COUNT(IF(discharge_to_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_visit_detail ev
+FROM @etl_project.@etl_dataset.cdm_visit_detail ev
 WHERE discharge_to_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_condition_occurrence'        AS table_name,
     'condition_concept_id'     AS concept_field,
@@ -316,11 +316,11 @@ SELECT
         ROUND(CAST(COUNT(IF(condition_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_condition_occurrence ev
 WHERE condition_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_condition_occurrence'        AS table_name,
     'condition_type_concept_id'     AS concept_field,
@@ -329,11 +329,11 @@ SELECT
         ROUND(CAST(COUNT(IF(condition_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_condition_occurrence ev
 WHERE condition_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_condition_occurrence'        AS table_name,
     'condition_status_concept_id'     AS concept_field,
@@ -342,11 +342,11 @@ SELECT
         ROUND(CAST(COUNT(IF(condition_status_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_condition_occurrence ev
 WHERE condition_status_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_procedure_occurrence'        AS table_name,
     'procedure_concept_id'     AS concept_field,
@@ -355,11 +355,11 @@ SELECT
         ROUND(CAST(COUNT(IF(procedure_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_procedure_occurrence ev
 WHERE procedure_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_procedure_occurrence'        AS table_name,
     'procedure_type_concept_id'     AS concept_field,
@@ -368,11 +368,11 @@ SELECT
         ROUND(CAST(COUNT(IF(procedure_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_procedure_occurrence ev
 WHERE procedure_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_procedure_occurrence'        AS table_name,
     'modifier_concept_id'     AS concept_field,
@@ -381,11 +381,11 @@ SELECT
         ROUND(CAST(COUNT(IF(modifier_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
+FROM @etl_project.@etl_dataset.cdm_procedure_occurrence ev
 WHERE modifier_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'observation_concept_id'     AS concept_field,
@@ -394,11 +394,11 @@ SELECT
         ROUND(CAST(COUNT(IF(observation_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE observation_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'observation_type_concept_id'     AS concept_field,
@@ -407,11 +407,11 @@ SELECT
         ROUND(CAST(COUNT(IF(observation_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE observation_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'value_as_concept_id'     AS concept_field,
@@ -420,11 +420,11 @@ SELECT
         ROUND(CAST(COUNT(IF(value_as_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE value_as_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'qualifier_concept_id'     AS concept_field,
@@ -433,11 +433,11 @@ SELECT
         ROUND(CAST(COUNT(IF(qualifier_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE qualifier_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_observation'        AS table_name,
     'unit_concept_id'     AS concept_field,
@@ -446,11 +446,11 @@ SELECT
         ROUND(CAST(COUNT(IF(unit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_observation ev
+FROM @etl_project.@etl_dataset.cdm_observation ev
 WHERE unit_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'measurement_concept_id'     AS concept_field,
@@ -459,11 +459,11 @@ SELECT
         ROUND(CAST(COUNT(IF(measurement_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE measurement_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'measurement_type_concept_id'     AS concept_field,
@@ -472,11 +472,11 @@ SELECT
         ROUND(CAST(COUNT(IF(measurement_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE measurement_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'operator_concept_id'     AS concept_field,
@@ -485,11 +485,11 @@ SELECT
         ROUND(CAST(COUNT(IF(operator_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE operator_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'value_as_concept_id'     AS concept_field,
@@ -498,11 +498,11 @@ SELECT
         ROUND(CAST(COUNT(IF(value_as_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE value_as_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_measurement'        AS table_name,
     'unit_concept_id'     AS concept_field,
@@ -511,11 +511,11 @@ SELECT
         ROUND(CAST(COUNT(IF(unit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
+FROM @etl_project.@etl_dataset.cdm_measurement ev
 WHERE unit_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_device_exposure'        AS table_name,
     'device_concept_id'     AS concept_field,
@@ -524,11 +524,11 @@ SELECT
         ROUND(CAST(COUNT(IF(device_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_device_exposure ev
+FROM @etl_project.@etl_dataset.cdm_device_exposure ev
 WHERE device_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_device_exposure'        AS table_name,
     'device_type_concept_id'     AS concept_field,
@@ -537,11 +537,11 @@ SELECT
         ROUND(CAST(COUNT(IF(device_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_device_exposure ev
+FROM @etl_project.@etl_dataset.cdm_device_exposure ev
 WHERE device_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_drug_exposure'        AS table_name,
     'drug_concept_id'     AS concept_field,
@@ -550,11 +550,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drug_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_drug_exposure ev
+FROM @etl_project.@etl_dataset.cdm_drug_exposure ev
 WHERE drug_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_drug_exposure'        AS table_name,
     'drug_type_concept_id'     AS concept_field,
@@ -563,11 +563,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drug_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_drug_exposure ev
+FROM @etl_project.@etl_dataset.cdm_drug_exposure ev
 WHERE drug_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_drug_exposure'        AS table_name,
     'route_concept_id'     AS concept_field,
@@ -576,11 +576,11 @@ SELECT
         ROUND(CAST(COUNT(IF(route_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_drug_exposure ev
+FROM @etl_project.@etl_dataset.cdm_drug_exposure ev
 WHERE route_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cost'        AS table_name,
     'cost_type_concept_id'     AS concept_field,
@@ -589,11 +589,11 @@ SELECT
         ROUND(CAST(COUNT(IF(cost_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cost ev
+FROM @etl_project.@etl_dataset.cdm_cost ev
 WHERE cost_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cost'        AS table_name,
     'currency_concept_id'     AS concept_field,
@@ -602,11 +602,11 @@ SELECT
         ROUND(CAST(COUNT(IF(currency_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cost ev
+FROM @etl_project.@etl_dataset.cdm_cost ev
 WHERE currency_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cost'        AS table_name,
     'revenue_code_concept_id'     AS concept_field,
@@ -615,11 +615,11 @@ SELECT
         ROUND(CAST(COUNT(IF(revenue_code_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cost ev
+FROM @etl_project.@etl_dataset.cdm_cost ev
 WHERE revenue_code_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cost'        AS table_name,
     'drg_concept_id'     AS concept_field,
@@ -628,11 +628,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drg_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cost ev
+FROM @etl_project.@etl_dataset.cdm_cost ev
 WHERE drg_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_condition_era'        AS table_name,
     'condition_concept_id'     AS concept_field,
@@ -641,11 +641,11 @@ SELECT
         ROUND(CAST(COUNT(IF(condition_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_condition_era ev
+FROM @etl_project.@etl_dataset.cdm_condition_era ev
 WHERE condition_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_drug_era'        AS table_name,
     'drug_concept_id'     AS concept_field,
@@ -654,11 +654,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drug_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_drug_era ev
+FROM @etl_project.@etl_dataset.cdm_drug_era ev
 WHERE drug_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_dose_era'        AS table_name,
     'drug_concept_id'     AS concept_field,
@@ -667,11 +667,11 @@ SELECT
         ROUND(CAST(COUNT(IF(drug_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_dose_era ev
+FROM @etl_project.@etl_dataset.cdm_dose_era ev
 WHERE drug_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_dose_era'        AS table_name,
     'unit_concept_id'     AS concept_field,
@@ -680,11 +680,11 @@ SELECT
         ROUND(CAST(COUNT(IF(unit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_dose_era ev
+FROM @etl_project.@etl_dataset.cdm_dose_era ev
 WHERE unit_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'specimen_concept_id'     AS concept_field,
@@ -693,11 +693,11 @@ SELECT
         ROUND(CAST(COUNT(IF(specimen_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE specimen_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'specimen_type_concept_id'     AS concept_field,
@@ -706,11 +706,11 @@ SELECT
         ROUND(CAST(COUNT(IF(specimen_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE specimen_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'unit_concept_id'     AS concept_field,
@@ -719,11 +719,11 @@ SELECT
         ROUND(CAST(COUNT(IF(unit_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE unit_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'anatomic_site_concept_id'     AS concept_field,
@@ -732,11 +732,11 @@ SELECT
         ROUND(CAST(COUNT(IF(anatomic_site_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE anatomic_site_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_specimen'        AS table_name,
     'disease_status_concept_id'     AS concept_field,
@@ -745,11 +745,11 @@ SELECT
         ROUND(CAST(COUNT(IF(disease_status_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_specimen ev
+FROM @etl_project.@etl_dataset.cdm_specimen ev
 WHERE disease_status_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note'        AS table_name,
     'note_type_concept_id'     AS concept_field,
@@ -758,11 +758,11 @@ SELECT
         ROUND(CAST(COUNT(IF(note_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note ev
+FROM @etl_project.@etl_dataset.cdm_note ev
 WHERE note_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note'        AS table_name,
     'note_class_concept_id'     AS concept_field,
@@ -771,11 +771,11 @@ SELECT
         ROUND(CAST(COUNT(IF(note_class_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note ev
+FROM @etl_project.@etl_dataset.cdm_note ev
 WHERE note_class_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note'        AS table_name,
     'encoding_concept_id'     AS concept_field,
@@ -784,11 +784,11 @@ SELECT
         ROUND(CAST(COUNT(IF(encoding_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note ev
+FROM @etl_project.@etl_dataset.cdm_note ev
 WHERE encoding_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note'        AS table_name,
     'language_concept_id'     AS concept_field,
@@ -797,11 +797,11 @@ SELECT
         ROUND(CAST(COUNT(IF(language_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note ev
+FROM @etl_project.@etl_dataset.cdm_note ev
 WHERE language_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note_nlp'        AS table_name,
     'section_concept_id'     AS concept_field,
@@ -810,11 +810,11 @@ SELECT
         ROUND(CAST(COUNT(IF(section_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note_nlp ev
+FROM @etl_project.@etl_dataset.cdm_note_nlp ev
 WHERE section_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_note_nlp'        AS table_name,
     'note_nlp_concept_id'     AS concept_field,
@@ -823,11 +823,11 @@ SELECT
         ROUND(CAST(COUNT(IF(note_nlp_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_note_nlp ev
+FROM @etl_project.@etl_dataset.cdm_note_nlp ev
 WHERE note_nlp_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_fact_relationship'        AS table_name,
     'domain_concept_id_1'     AS concept_field,
@@ -836,11 +836,11 @@ SELECT
         ROUND(CAST(COUNT(IF(domain_concept_id_1 > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_fact_relationship ev
+FROM @etl_project.@etl_dataset.cdm_fact_relationship ev
 WHERE domain_concept_id_1 IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_fact_relationship'        AS table_name,
     'domain_concept_id_2'     AS concept_field,
@@ -849,11 +849,11 @@ SELECT
         ROUND(CAST(COUNT(IF(domain_concept_id_2 > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_fact_relationship ev
+FROM @etl_project.@etl_dataset.cdm_fact_relationship ev
 WHERE domain_concept_id_2 IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_fact_relationship'        AS table_name,
     'relationship_concept_id'     AS concept_field,
@@ -862,11 +862,11 @@ SELECT
         ROUND(CAST(COUNT(IF(relationship_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_fact_relationship ev
+FROM @etl_project.@etl_dataset.cdm_fact_relationship ev
 WHERE relationship_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_cohort_attribute'        AS table_name,
     'value_as_concept_id'     AS concept_field,
@@ -875,11 +875,11 @@ SELECT
         ROUND(CAST(COUNT(IF(value_as_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_cohort_attribute ev
+FROM @etl_project.@etl_dataset.cdm_cohort_attribute ev
 WHERE value_as_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_metadata'        AS table_name,
     'metadata_concept_id'     AS concept_field,
@@ -888,11 +888,11 @@ SELECT
         ROUND(CAST(COUNT(IF(metadata_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_metadata ev
+FROM @etl_project.@etl_dataset.cdm_metadata ev
 WHERE metadata_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_metadata'        AS table_name,
     'metadata_type_concept_id'     AS concept_field,
@@ -901,11 +901,11 @@ SELECT
         ROUND(CAST(COUNT(IF(metadata_type_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_metadata ev
+FROM @etl_project.@etl_dataset.cdm_metadata ev
 WHERE metadata_type_concept_id IS NOT NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_mapping_rate
+INSERT INTO @metrics_project.@metrics_dataset.me_mapping_rate
 SELECT
     'cdm_metadata'        AS table_name,
     'value_as_concept_id'     AS concept_field,
@@ -914,7 +914,7 @@ SELECT
         ROUND(CAST(COUNT(IF(value_as_concept_id > 0, 1, NULL)) AS FLOAT64) / COUNT(*) * 100, 2),
         0)    AS percent,
     COUNT(*)                AS total
-FROM `@etl_project`.@etl_dataset.cdm_metadata ev
+FROM @etl_project.@etl_dataset.cdm_metadata ev
 WHERE value_as_concept_id IS NOT NULL
 ;
 

--- a/test/metrics_gen/me_persons_visits.sql
+++ b/test/metrics_gen/me_persons_visits.sql
@@ -20,8 +20,8 @@
 -- create database mimic_ metrics;
 -- ----------------------------------------------------------------------------------------------
 
-drop table if exists `@metrics_project`.@metrics_dataset.me_persons_visits;
-create table `@metrics_project`.@metrics_dataset.me_persons_visits
+drop table if exists @metrics_project.@metrics_dataset.me_persons_visits;
+create table @metrics_project.@metrics_dataset.me_persons_visits
 (
         category string,
         name string,
@@ -31,25 +31,25 @@ create table `@metrics_project`.@metrics_dataset.me_persons_visits
 -- ----------------------------------------------------------------------------------------------
 -- Number of  persons
 -- ----------------------------------------------------------------------------------------------
-insert into `@metrics_project`.@metrics_dataset.me_persons_visits
+insert into @metrics_project.@metrics_dataset.me_persons_visits
 select 'Number of persons' as category, 'Total' as name,  count(*) as count
-from `@etl_project`.@etl_dataset.cdm_person
+from @etl_project.@etl_dataset.cdm_person
 ;
 
-insert into `@metrics_project`.@metrics_dataset.me_persons_visits
+insert into @metrics_project.@metrics_dataset.me_persons_visits
 select 'Number of persons by Race' as category, vc.concept_name as name,  count(*) as count
-from `@etl_project`.@etl_dataset.cdm_person per
-left join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_person per
+left join @etl_project.@etl_dataset.voc_concept vc
     on per.race_concept_id = vc.concept_id
 group by vc.concept_name
 order by vc.concept_name
 ;
 
 
-insert into `@metrics_project`.@metrics_dataset.me_persons_visits
+insert into @metrics_project.@metrics_dataset.me_persons_visits
 select 'Number of persons by Ethnicity' as category, vc.concept_name as name,  count(*) as count
-from `@etl_project`.@etl_dataset.cdm_person per
-left join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_person per
+left join @etl_project.@etl_dataset.voc_concept vc
     on per.ethnicity_concept_id = vc.concept_id
 group by vc.concept_name
 order by vc.concept_name
@@ -61,19 +61,19 @@ order by vc.concept_name
 -- Stratified by visit_concept_id
 -- ----------------------------------------------------------------------------------------------
 
-insert into `@metrics_project`.@metrics_dataset.me_persons_visits
+insert into @metrics_project.@metrics_dataset.me_persons_visits
 select 'Number of visits' as category, 'Total' as name,  count(*) as count
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence
+from @etl_project.@etl_dataset.cdm_visit_occurrence
 ;
 
 
-insert into `@metrics_project`.@metrics_dataset.me_persons_visits
+insert into @metrics_project.@metrics_dataset.me_persons_visits
 select 'Number of visits by visit_concept_id' as category, vc.concept_name as name,  count(*) as count
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
-left join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_occurrence vis
+left join @etl_project.@etl_dataset.voc_concept vc
     on vis.visit_concept_id = vc.concept_id
 group by vc.concept_name
 order by vc.concept_name
 ;
 
-select * from `@metrics_project`.@metrics_dataset.me_persons_visits order by category, name;
+select * from @metrics_project.@metrics_dataset.me_persons_visits order by category, name;

--- a/test/metrics_gen/me_see_result_from_conf.sql
+++ b/test/metrics_gen/me_see_result_from_conf.sql
@@ -1,120 +1,120 @@
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_care_site rt
+from @metrics_project.@metrics_dataset.me_top_cdm_care_site rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_provider rt
+from @metrics_project.@metrics_dataset.me_top_cdm_provider rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_person rt
+from @metrics_project.@metrics_dataset.me_top_cdm_person rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_death rt
+from @metrics_project.@metrics_dataset.me_top_cdm_death rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_observation_period rt
+from @metrics_project.@metrics_dataset.me_top_cdm_observation_period rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period rt
+from @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence rt
+from @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail rt
+from @metrics_project.@metrics_dataset.me_top_cdm_visit_detail rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence rt
+from @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence rt
+from @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_observation rt
+from @metrics_project.@metrics_dataset.me_top_cdm_observation rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_measurement rt
+from @metrics_project.@metrics_dataset.me_top_cdm_measurement rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure rt
+from @metrics_project.@metrics_dataset.me_top_cdm_device_exposure rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure rt
+from @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_cost rt
+from @metrics_project.@metrics_dataset.me_top_cdm_cost rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_condition_era rt
+from @metrics_project.@metrics_dataset.me_top_cdm_condition_era rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_drug_era rt
+from @metrics_project.@metrics_dataset.me_top_cdm_drug_era rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era rt
+from @metrics_project.@metrics_dataset.me_top_cdm_dose_era rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_specimen rt
+from @metrics_project.@metrics_dataset.me_top_cdm_specimen rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_note rt
+from @metrics_project.@metrics_dataset.me_top_cdm_note rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp rt
+from @metrics_project.@metrics_dataset.me_top_cdm_note_nlp rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship rt
+from @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_cohort_attribute rt
+from @metrics_project.@metrics_dataset.me_top_cdm_cohort_attribute rt
 order by concept_field, category, count desc
 ;
 
 SELECT *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_metadata rt
+from @metrics_project.@metrics_dataset.me_top_cdm_metadata rt
 order by concept_field, category, count desc
 ;
 

--- a/test/metrics_gen/me_top100_from_conf.sql
+++ b/test/metrics_gen/me_top100_from_conf.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_care_site;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_care_site
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_care_site;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_care_site
 (
     concept_field     STRING,
     category          STRING,
@@ -10,7 +10,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_care_site
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_care_site
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_care_site
 SELECT
     'place_of_service_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -19,10 +19,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_care_site ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_care_site ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.place_of_service_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_care_site'
 where ev.place_of_service_concept_id <> 0
 group by ev.place_of_service_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -30,7 +30,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_care_site
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_care_site
 SELECT
     'place_of_service_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -39,8 +39,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_care_site ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_care_site ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_care_site'
 where ev.place_of_service_concept_id = 0
 group by ev.place_of_service_source_value, tt.count
@@ -48,8 +48,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_provider;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_provider
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_provider;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_provider
 (
     concept_field     STRING,
     category          STRING,
@@ -60,7 +60,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_provider
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_provider
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_provider
 SELECT
     'specialty_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -69,10 +69,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_provider ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_provider ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.specialty_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_provider'
 where ev.specialty_concept_id <> 0
 group by ev.specialty_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -80,7 +80,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_provider
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_provider
 SELECT
     'specialty_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -89,8 +89,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_provider ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_provider ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_provider'
 where ev.specialty_concept_id = 0
 group by ev.specialty_source_value, tt.count
@@ -98,7 +98,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_provider
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_provider
 SELECT
     'gender_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -107,10 +107,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_provider ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_provider ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.gender_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_provider'
 where ev.gender_concept_id <> 0
 group by ev.gender_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -118,7 +118,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_provider
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_provider
 SELECT
     'gender_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -127,8 +127,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_provider ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_provider ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_provider'
 where ev.gender_concept_id = 0
 group by ev.gender_source_value, tt.count
@@ -136,8 +136,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_person;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_person
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_person;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_person
 (
     concept_field     STRING,
     category          STRING,
@@ -148,7 +148,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_person
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_person
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_person
 SELECT
     'gender_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -157,10 +157,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_person ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_person ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.gender_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_person'
 where ev.gender_concept_id <> 0
 group by ev.gender_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -168,7 +168,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_person
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_person
 SELECT
     'gender_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -177,8 +177,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_person ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_person ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_person'
 where ev.gender_concept_id = 0
 group by ev.gender_source_value, tt.count
@@ -186,7 +186,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_person
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_person
 SELECT
     'race_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -195,10 +195,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_person ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_person ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.race_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_person'
 where ev.race_concept_id <> 0
 group by ev.race_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -206,7 +206,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_person
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_person
 SELECT
     'race_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -215,8 +215,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_person ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_person ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_person'
 where ev.race_concept_id = 0
 group by ev.race_source_value, tt.count
@@ -224,7 +224,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_person
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_person
 SELECT
     'ethnicity_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -233,10 +233,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_person ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_person ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.ethnicity_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_person'
 where ev.ethnicity_concept_id <> 0
 group by ev.ethnicity_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -244,7 +244,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_person
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_person
 SELECT
     'ethnicity_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -253,8 +253,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_person ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_person ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_person'
 where ev.ethnicity_concept_id = 0
 group by ev.ethnicity_source_value, tt.count
@@ -262,8 +262,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_death;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_death
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_death;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_death
 (
     concept_field     STRING,
     category          STRING,
@@ -274,7 +274,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_death
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_death
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_death
 SELECT
     'death_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -283,10 +283,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_death ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_death ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.death_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_death'
 where ev.death_type_concept_id <> 0
 group by ev.death_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -294,7 +294,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_death
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_death
 SELECT
     'death_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -303,8 +303,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_death ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_death ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_death'
 where ev.death_type_concept_id = 0
 group by ev.death_type_concept_id, tt.count
@@ -312,7 +312,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_death
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_death
 SELECT
     'cause_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -321,10 +321,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_death ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_death ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.cause_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_death'
 where ev.cause_concept_id <> 0
 group by ev.cause_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -332,7 +332,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_death
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_death
 SELECT
     'cause_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -341,8 +341,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_death ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_death ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_death'
 where ev.cause_concept_id = 0
 group by ev.cause_source_value, tt.count
@@ -350,8 +350,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_observation_period;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_observation_period
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_observation_period;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_observation_period
 (
     concept_field     STRING,
     category          STRING,
@@ -362,7 +362,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_observation_period
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation_period
 SELECT
     'period_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -371,10 +371,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation_period ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_observation_period ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.period_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation_period'
 where ev.period_type_concept_id <> 0
 group by ev.period_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -382,7 +382,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation_period
 SELECT
     'period_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -391,8 +391,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation_period ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_observation_period ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation_period'
 where ev.period_type_concept_id = 0
 group by ev.period_type_concept_id, tt.count
@@ -400,8 +400,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 (
     concept_field     STRING,
     category          STRING,
@@ -412,7 +412,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 SELECT
     'payer_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -421,10 +421,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.payer_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_payer_plan_period'
 where ev.payer_concept_id <> 0
 group by ev.payer_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -432,7 +432,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 SELECT
     'payer_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -441,8 +441,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_payer_plan_period'
 where ev.payer_concept_id = 0
 group by ev.payer_source_value, tt.count
@@ -450,7 +450,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 SELECT
     'plan_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -459,10 +459,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.plan_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_payer_plan_period'
 where ev.plan_concept_id <> 0
 group by ev.plan_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -470,7 +470,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 SELECT
     'plan_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -479,8 +479,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_payer_plan_period'
 where ev.plan_concept_id = 0
 group by ev.plan_source_value, tt.count
@@ -488,7 +488,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 SELECT
     'sponsor_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -497,10 +497,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.sponsor_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_payer_plan_period'
 where ev.sponsor_concept_id <> 0
 group by ev.sponsor_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -508,7 +508,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 SELECT
     'sponsor_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -517,8 +517,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_payer_plan_period'
 where ev.sponsor_concept_id = 0
 group by ev.sponsor_source_value, tt.count
@@ -526,7 +526,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 SELECT
     'stop_reason_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -535,10 +535,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.stop_reason_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_payer_plan_period'
 where ev.stop_reason_concept_id <> 0
 group by ev.stop_reason_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -546,7 +546,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period
 SELECT
     'stop_reason_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -555,8 +555,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_payer_plan_period'
 where ev.stop_reason_concept_id = 0
 group by ev.stop_reason_source_value, tt.count
@@ -564,8 +564,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 (
     concept_field     STRING,
     category          STRING,
@@ -576,7 +576,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'visit_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -585,10 +585,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.visit_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.visit_concept_id <> 0
 group by ev.visit_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -596,7 +596,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'visit_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -605,8 +605,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.visit_concept_id = 0
 group by ev.visit_concept_id, tt.count
@@ -614,7 +614,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'visit_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -623,10 +623,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.visit_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.visit_type_concept_id <> 0
 group by ev.visit_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -634,7 +634,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'visit_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -643,8 +643,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.visit_type_concept_id = 0
 group by ev.visit_type_concept_id, tt.count
@@ -652,7 +652,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'visit_source_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -661,10 +661,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.visit_source_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.visit_source_concept_id <> 0
 group by ev.visit_source_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -672,7 +672,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'visit_source_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -681,8 +681,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.visit_source_concept_id = 0
 group by ev.visit_source_concept_id, tt.count
@@ -690,7 +690,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'admitting_source_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -699,10 +699,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.admitting_source_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.admitting_source_concept_id <> 0
 group by ev.admitting_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -710,7 +710,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'admitting_source_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -719,8 +719,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.admitting_source_concept_id = 0
 group by ev.admitting_source_value, tt.count
@@ -728,7 +728,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'discharge_to_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -737,10 +737,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.discharge_to_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.discharge_to_concept_id <> 0
 group by ev.discharge_to_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -748,7 +748,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence
 SELECT
     'discharge_to_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -757,8 +757,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_occurrence'
 where ev.discharge_to_concept_id = 0
 group by ev.discharge_to_source_value, tt.count
@@ -766,8 +766,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_visit_detail;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 (
     concept_field     STRING,
     category          STRING,
@@ -778,7 +778,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'visit_detail_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -787,10 +787,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.visit_detail_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.visit_detail_concept_id <> 0
 group by ev.visit_detail_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -798,7 +798,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'visit_detail_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -807,8 +807,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.visit_detail_concept_id = 0
 group by ev.visit_detail_concept_id, tt.count
@@ -816,7 +816,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'visit_detail_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -825,10 +825,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.visit_detail_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.visit_detail_type_concept_id <> 0
 group by ev.visit_detail_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -836,7 +836,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'visit_detail_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -845,8 +845,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.visit_detail_type_concept_id = 0
 group by ev.visit_detail_type_concept_id, tt.count
@@ -854,7 +854,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'visit_detail_source_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -863,10 +863,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.visit_detail_source_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.visit_detail_source_concept_id <> 0
 group by ev.visit_detail_source_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -874,7 +874,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'visit_detail_source_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -883,8 +883,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.visit_detail_source_concept_id = 0
 group by ev.visit_detail_source_concept_id, tt.count
@@ -892,7 +892,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'admitting_source_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -901,10 +901,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.admitting_source_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.admitting_source_concept_id <> 0
 group by ev.admitting_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -912,7 +912,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'admitting_source_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -921,8 +921,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.admitting_source_concept_id = 0
 group by ev.admitting_source_value, tt.count
@@ -930,7 +930,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'discharge_to_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -939,10 +939,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.discharge_to_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.discharge_to_concept_id <> 0
 group by ev.discharge_to_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -950,7 +950,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_visit_detail
 SELECT
     'discharge_to_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -959,8 +959,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_visit_detail ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_visit_detail'
 where ev.discharge_to_concept_id = 0
 group by ev.discharge_to_source_value, tt.count
@@ -968,8 +968,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence
 (
     concept_field     STRING,
     category          STRING,
@@ -980,7 +980,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence
 SELECT
     'condition_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -989,10 +989,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_condition_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.condition_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_condition_occurrence'
 where ev.condition_concept_id <> 0
 group by ev.condition_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1000,7 +1000,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence
 SELECT
     'condition_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1009,8 +1009,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_condition_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_condition_occurrence'
 where ev.condition_concept_id = 0
 group by ev.condition_source_value, tt.count
@@ -1018,7 +1018,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence
 SELECT
     'condition_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1027,10 +1027,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_condition_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.condition_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_condition_occurrence'
 where ev.condition_type_concept_id <> 0
 group by ev.condition_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1038,7 +1038,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence
 SELECT
     'condition_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1047,8 +1047,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_condition_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_condition_occurrence'
 where ev.condition_type_concept_id = 0
 group by ev.condition_type_concept_id, tt.count
@@ -1056,7 +1056,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence
 SELECT
     'condition_status_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1065,10 +1065,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_condition_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.condition_status_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_condition_occurrence'
 where ev.condition_status_concept_id <> 0
 group by ev.condition_status_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1076,7 +1076,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence
 SELECT
     'condition_status_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1085,8 +1085,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_condition_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_condition_occurrence'
 where ev.condition_status_concept_id = 0
 group by ev.condition_status_source_value, tt.count
@@ -1094,8 +1094,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence
 (
     concept_field     STRING,
     category          STRING,
@@ -1106,7 +1106,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence
 SELECT
     'procedure_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1115,10 +1115,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_procedure_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.procedure_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_procedure_occurrence'
 where ev.procedure_concept_id <> 0
 group by ev.procedure_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1126,7 +1126,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence
 SELECT
     'procedure_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1135,8 +1135,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_procedure_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_procedure_occurrence'
 where ev.procedure_concept_id = 0
 group by ev.procedure_source_value, tt.count
@@ -1144,7 +1144,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence
 SELECT
     'procedure_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1153,10 +1153,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_procedure_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.procedure_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_procedure_occurrence'
 where ev.procedure_type_concept_id <> 0
 group by ev.procedure_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1164,7 +1164,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence
 SELECT
     'procedure_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1173,8 +1173,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_procedure_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_procedure_occurrence'
 where ev.procedure_type_concept_id = 0
 group by ev.procedure_type_concept_id, tt.count
@@ -1182,7 +1182,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence
 SELECT
     'modifier_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1191,10 +1191,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_procedure_occurrence ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.modifier_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_procedure_occurrence'
 where ev.modifier_concept_id <> 0
 group by ev.modifier_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1202,7 +1202,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence
 SELECT
     'modifier_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1211,8 +1211,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_procedure_occurrence ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_procedure_occurrence'
 where ev.modifier_concept_id = 0
 group by ev.modifier_source_value, tt.count
@@ -1220,8 +1220,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_observation;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_observation;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_observation
 (
     concept_field     STRING,
     category          STRING,
@@ -1232,7 +1232,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_observation
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'observation_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1241,10 +1241,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.observation_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.observation_concept_id <> 0
 group by ev.observation_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1252,7 +1252,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'observation_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1261,8 +1261,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.observation_concept_id = 0
 group by ev.observation_source_value, tt.count
@@ -1270,7 +1270,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'observation_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1279,10 +1279,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.observation_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.observation_type_concept_id <> 0
 group by ev.observation_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1290,7 +1290,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'observation_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1299,8 +1299,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.observation_type_concept_id = 0
 group by ev.observation_type_concept_id, tt.count
@@ -1308,7 +1308,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'value_as_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1317,10 +1317,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.value_as_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.value_as_concept_id <> 0
 group by ev.value_as_string, vc.concept_id, vc.concept_name, tt.count
@@ -1328,7 +1328,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'value_as_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1337,8 +1337,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.value_as_concept_id = 0
 group by ev.value_as_string, tt.count
@@ -1346,7 +1346,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'qualifier_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1355,10 +1355,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.qualifier_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.qualifier_concept_id <> 0
 group by ev.qualifier_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1366,7 +1366,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'qualifier_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1375,8 +1375,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.qualifier_concept_id = 0
 group by ev.qualifier_source_value, tt.count
@@ -1384,7 +1384,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'unit_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1393,10 +1393,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.unit_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.unit_concept_id <> 0
 group by ev.unit_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1404,7 +1404,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_observation
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_observation
 SELECT
     'unit_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1413,8 +1413,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_observation ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_observation ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_observation'
 where ev.unit_concept_id = 0
 group by ev.unit_source_value, tt.count
@@ -1422,8 +1422,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_measurement;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_measurement;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_measurement
 (
     concept_field     STRING,
     category          STRING,
@@ -1434,7 +1434,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'measurement_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1443,10 +1443,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.measurement_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.measurement_concept_id <> 0
 group by ev.measurement_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1454,7 +1454,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'measurement_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1463,8 +1463,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.measurement_concept_id = 0
 group by ev.measurement_source_value, tt.count
@@ -1472,7 +1472,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'measurement_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1481,10 +1481,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.measurement_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.measurement_type_concept_id <> 0
 group by ev.measurement_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1492,7 +1492,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'measurement_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1501,8 +1501,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.measurement_type_concept_id = 0
 group by ev.measurement_type_concept_id, tt.count
@@ -1510,7 +1510,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'operator_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1519,10 +1519,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.operator_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.operator_concept_id <> 0
 group by ev.operator_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1530,7 +1530,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'operator_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1539,8 +1539,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.operator_concept_id = 0
 group by ev.operator_concept_id, tt.count
@@ -1548,7 +1548,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'value_as_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1557,10 +1557,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.value_as_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.value_as_concept_id <> 0
 group by ev.value_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1568,7 +1568,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'value_as_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1577,8 +1577,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.value_as_concept_id = 0
 group by ev.value_source_value, tt.count
@@ -1586,7 +1586,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'unit_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1595,10 +1595,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.unit_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.unit_concept_id <> 0
 group by ev.unit_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1606,7 +1606,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'unit_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1615,8 +1615,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_measurement ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_measurement ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_measurement'
 where ev.unit_concept_id = 0
 group by ev.unit_source_value, tt.count
@@ -1624,8 +1624,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_device_exposure;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_device_exposure
 (
     concept_field     STRING,
     category          STRING,
@@ -1636,7 +1636,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_device_exposure
 SELECT
     'device_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1645,10 +1645,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_device_exposure ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_device_exposure ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.device_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_device_exposure'
 where ev.device_concept_id <> 0
 group by ev.device_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1656,7 +1656,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_device_exposure
 SELECT
     'device_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1665,8 +1665,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_device_exposure ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_device_exposure ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_device_exposure'
 where ev.device_concept_id = 0
 group by ev.device_source_value, tt.count
@@ -1674,7 +1674,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_device_exposure
 SELECT
     'device_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1683,10 +1683,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_device_exposure ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_device_exposure ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.device_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_device_exposure'
 where ev.device_type_concept_id <> 0
 group by ev.device_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1694,7 +1694,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_device_exposure
 SELECT
     'device_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1703,8 +1703,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_device_exposure ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_device_exposure ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_device_exposure'
 where ev.device_type_concept_id = 0
 group by ev.device_type_concept_id, tt.count
@@ -1712,8 +1712,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure
 (
     concept_field     STRING,
     category          STRING,
@@ -1724,7 +1724,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure
 SELECT
     'drug_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1733,10 +1733,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_drug_exposure ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_drug_exposure ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.drug_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_drug_exposure'
 where ev.drug_concept_id <> 0
 group by ev.drug_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1744,7 +1744,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure
 SELECT
     'drug_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1753,8 +1753,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_drug_exposure ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_drug_exposure ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_drug_exposure'
 where ev.drug_concept_id = 0
 group by ev.drug_source_value, tt.count
@@ -1762,7 +1762,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure
 SELECT
     'drug_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1771,10 +1771,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_drug_exposure ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_drug_exposure ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.drug_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_drug_exposure'
 where ev.drug_type_concept_id <> 0
 group by ev.drug_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1782,7 +1782,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure
 SELECT
     'drug_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1791,8 +1791,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_drug_exposure ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_drug_exposure ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_drug_exposure'
 where ev.drug_type_concept_id = 0
 group by ev.drug_type_concept_id, tt.count
@@ -1800,7 +1800,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure
 SELECT
     'route_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1809,10 +1809,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_drug_exposure ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_drug_exposure ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.route_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_drug_exposure'
 where ev.route_concept_id <> 0
 group by ev.route_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1820,7 +1820,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure
 SELECT
     'route_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1829,8 +1829,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_drug_exposure ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_drug_exposure ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_drug_exposure'
 where ev.route_concept_id = 0
 group by ev.route_source_value, tt.count
@@ -1838,8 +1838,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_cost;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_cost;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_cost
 (
     concept_field     STRING,
     category          STRING,
@@ -1850,7 +1850,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_cost
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cost
 SELECT
     'cost_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1859,10 +1859,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cost ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_cost ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.cost_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cost'
 where ev.cost_type_concept_id <> 0
 group by ev.cost_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1870,7 +1870,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cost
 SELECT
     'cost_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1879,8 +1879,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cost ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_cost ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cost'
 where ev.cost_type_concept_id = 0
 group by ev.cost_type_concept_id, tt.count
@@ -1888,7 +1888,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cost
 SELECT
     'currency_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1897,10 +1897,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cost ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_cost ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.currency_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cost'
 where ev.currency_concept_id <> 0
 group by ev.currency_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -1908,7 +1908,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cost
 SELECT
     'currency_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1917,8 +1917,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cost ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_cost ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cost'
 where ev.currency_concept_id = 0
 group by ev.currency_concept_id, tt.count
@@ -1926,7 +1926,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cost
 SELECT
     'revenue_code_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1935,10 +1935,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cost ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_cost ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.revenue_code_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cost'
 where ev.revenue_code_concept_id <> 0
 group by ev.revenue_code_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1946,7 +1946,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cost
 SELECT
     'revenue_code_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1955,8 +1955,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cost ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_cost ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cost'
 where ev.revenue_code_concept_id = 0
 group by ev.revenue_code_source_value, tt.count
@@ -1964,7 +1964,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cost
 SELECT
     'drg_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -1973,10 +1973,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cost ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_cost ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.drg_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cost'
 where ev.drg_concept_id <> 0
 group by ev.drg_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -1984,7 +1984,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cost
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cost
 SELECT
     'drg_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -1993,8 +1993,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cost ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_cost ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cost'
 where ev.drg_concept_id = 0
 group by ev.drg_source_value, tt.count
@@ -2002,8 +2002,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_condition_era;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_condition_era
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_condition_era;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_condition_era
 (
     concept_field     STRING,
     category          STRING,
@@ -2014,7 +2014,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_condition_era
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_condition_era
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_condition_era
 SELECT
     'condition_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2023,10 +2023,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_condition_era ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_condition_era ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.condition_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_condition_era'
 where ev.condition_concept_id <> 0
 group by ev.condition_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2034,7 +2034,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_condition_era
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_condition_era
 SELECT
     'condition_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2043,8 +2043,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_condition_era ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_condition_era ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_condition_era'
 where ev.condition_concept_id = 0
 group by ev.condition_concept_id, tt.count
@@ -2052,8 +2052,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_drug_era;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_drug_era
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_drug_era;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_drug_era
 (
     concept_field     STRING,
     category          STRING,
@@ -2064,7 +2064,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_drug_era
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_drug_era
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_drug_era
 SELECT
     'drug_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2073,10 +2073,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_drug_era ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_drug_era ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.drug_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_drug_era'
 where ev.drug_concept_id <> 0
 group by ev.drug_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2084,7 +2084,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_drug_era
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_drug_era
 SELECT
     'drug_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2093,8 +2093,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_drug_era ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_drug_era ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_drug_era'
 where ev.drug_concept_id = 0
 group by ev.drug_concept_id, tt.count
@@ -2102,8 +2102,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_dose_era;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_dose_era
 (
     concept_field     STRING,
     category          STRING,
@@ -2114,7 +2114,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_dose_era
 SELECT
     'drug_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2123,10 +2123,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_dose_era ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_dose_era ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.drug_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_dose_era'
 where ev.drug_concept_id <> 0
 group by ev.drug_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2134,7 +2134,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_dose_era
 SELECT
     'drug_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2143,8 +2143,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_dose_era ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_dose_era ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_dose_era'
 where ev.drug_concept_id = 0
 group by ev.drug_concept_id, tt.count
@@ -2152,7 +2152,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_dose_era
 SELECT
     'unit_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2161,10 +2161,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_dose_era ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_dose_era ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.unit_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_dose_era'
 where ev.unit_concept_id <> 0
 group by ev.unit_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2172,7 +2172,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_dose_era
 SELECT
     'unit_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2181,8 +2181,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_dose_era ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_dose_era ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_dose_era'
 where ev.unit_concept_id = 0
 group by ev.unit_concept_id, tt.count
@@ -2190,8 +2190,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_specimen;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_specimen;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_specimen
 (
     concept_field     STRING,
     category          STRING,
@@ -2202,7 +2202,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'specimen_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2211,10 +2211,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.specimen_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.specimen_concept_id <> 0
 group by ev.specimen_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -2222,7 +2222,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'specimen_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2231,8 +2231,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.specimen_concept_id = 0
 group by ev.specimen_source_value, tt.count
@@ -2240,7 +2240,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'specimen_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2249,10 +2249,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.specimen_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.specimen_type_concept_id <> 0
 group by ev.specimen_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2260,7 +2260,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'specimen_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2269,8 +2269,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.specimen_type_concept_id = 0
 group by ev.specimen_type_concept_id, tt.count
@@ -2278,7 +2278,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'unit_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2287,10 +2287,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.unit_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.unit_concept_id <> 0
 group by ev.unit_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -2298,7 +2298,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'unit_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2307,8 +2307,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.unit_concept_id = 0
 group by ev.unit_source_value, tt.count
@@ -2316,7 +2316,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'anatomic_site_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2325,10 +2325,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.anatomic_site_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.anatomic_site_concept_id <> 0
 group by ev.anatomic_site_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -2336,7 +2336,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'anatomic_site_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2345,8 +2345,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.anatomic_site_concept_id = 0
 group by ev.anatomic_site_source_value, tt.count
@@ -2354,7 +2354,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'disease_status_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2363,10 +2363,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.disease_status_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.disease_status_concept_id <> 0
 group by ev.disease_status_source_value, vc.concept_id, vc.concept_name, tt.count
@@ -2374,7 +2374,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_specimen
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_specimen
 SELECT
     'disease_status_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2383,8 +2383,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_specimen ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_specimen ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_specimen'
 where ev.disease_status_concept_id = 0
 group by ev.disease_status_source_value, tt.count
@@ -2392,8 +2392,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_note;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_note
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_note;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_note
 (
     concept_field     STRING,
     category          STRING,
@@ -2404,7 +2404,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_note
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note
 SELECT
     'note_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2413,10 +2413,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_note ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.note_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note'
 where ev.note_type_concept_id <> 0
 group by ev.note_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2424,7 +2424,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note
 SELECT
     'note_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2433,8 +2433,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_note ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note'
 where ev.note_type_concept_id = 0
 group by ev.note_type_concept_id, tt.count
@@ -2442,7 +2442,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note
 SELECT
     'note_class_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2451,10 +2451,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_note ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.note_class_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note'
 where ev.note_class_concept_id <> 0
 group by ev.note_class_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2462,7 +2462,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note
 SELECT
     'note_class_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2471,8 +2471,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_note ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note'
 where ev.note_class_concept_id = 0
 group by ev.note_class_concept_id, tt.count
@@ -2480,7 +2480,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note
 SELECT
     'encoding_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2489,10 +2489,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_note ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.encoding_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note'
 where ev.encoding_concept_id <> 0
 group by ev.encoding_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2500,7 +2500,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note
 SELECT
     'encoding_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2509,8 +2509,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_note ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note'
 where ev.encoding_concept_id = 0
 group by ev.encoding_concept_id, tt.count
@@ -2518,7 +2518,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note
 SELECT
     'language_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2527,10 +2527,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_note ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.language_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note'
 where ev.language_concept_id <> 0
 group by ev.language_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2538,7 +2538,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note
 SELECT
     'language_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2547,8 +2547,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_note ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note'
 where ev.language_concept_id = 0
 group by ev.language_concept_id, tt.count
@@ -2556,8 +2556,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_note_nlp;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_note_nlp
 (
     concept_field     STRING,
     category          STRING,
@@ -2568,7 +2568,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note_nlp
 SELECT
     'section_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2577,10 +2577,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note_nlp ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_note_nlp ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.section_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note_nlp'
 where ev.section_concept_id <> 0
 group by ev.section_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2588,7 +2588,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note_nlp
 SELECT
     'section_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2597,8 +2597,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note_nlp ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_note_nlp ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note_nlp'
 where ev.section_concept_id = 0
 group by ev.section_concept_id, tt.count
@@ -2606,7 +2606,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note_nlp
 SELECT
     'note_nlp_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2615,10 +2615,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note_nlp ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_note_nlp ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.note_nlp_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note_nlp'
 where ev.note_nlp_concept_id <> 0
 group by ev.note_nlp_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2626,7 +2626,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_note_nlp
 SELECT
     'note_nlp_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2635,8 +2635,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_note_nlp ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_note_nlp ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_note_nlp'
 where ev.note_nlp_concept_id = 0
 group by ev.note_nlp_concept_id, tt.count
@@ -2644,8 +2644,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship
 (
     concept_field     STRING,
     category          STRING,
@@ -2656,7 +2656,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship
 SELECT
     'domain_concept_id_1'     AS concept_field,
     'Mapped'              AS category,
@@ -2665,10 +2665,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_fact_relationship ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_fact_relationship ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.domain_concept_id_1 = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_fact_relationship'
 where ev.domain_concept_id_1 <> 0
 group by ev.domain_concept_id_1, vc.concept_id, vc.concept_name, tt.count
@@ -2676,7 +2676,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship
 SELECT
     'domain_concept_id_1'      AS concept_field,
     'Unmapped'            AS category,
@@ -2685,8 +2685,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_fact_relationship ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_fact_relationship ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_fact_relationship'
 where ev.domain_concept_id_1 = 0
 group by ev.domain_concept_id_1, tt.count
@@ -2694,7 +2694,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship
 SELECT
     'domain_concept_id_2'     AS concept_field,
     'Mapped'              AS category,
@@ -2703,10 +2703,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_fact_relationship ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_fact_relationship ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.domain_concept_id_2 = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_fact_relationship'
 where ev.domain_concept_id_2 <> 0
 group by ev.domain_concept_id_2, vc.concept_id, vc.concept_name, tt.count
@@ -2714,7 +2714,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship
 SELECT
     'domain_concept_id_2'      AS concept_field,
     'Unmapped'            AS category,
@@ -2723,8 +2723,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_fact_relationship ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_fact_relationship ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_fact_relationship'
 where ev.domain_concept_id_2 = 0
 group by ev.domain_concept_id_2, tt.count
@@ -2732,7 +2732,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship
 SELECT
     'relationship_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2741,10 +2741,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_fact_relationship ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_fact_relationship ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.relationship_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_fact_relationship'
 where ev.relationship_concept_id <> 0
 group by ev.relationship_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2752,7 +2752,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship
 SELECT
     'relationship_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2761,8 +2761,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_fact_relationship ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_fact_relationship ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_fact_relationship'
 where ev.relationship_concept_id = 0
 group by ev.relationship_concept_id, tt.count
@@ -2770,8 +2770,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_cohort_attribute;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_cohort_attribute
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_cohort_attribute;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_cohort_attribute
 (
     concept_field     STRING,
     category          STRING,
@@ -2782,7 +2782,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_cohort_attribute
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cohort_attribute
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cohort_attribute
 SELECT
     'value_as_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2791,10 +2791,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cohort_attribute ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_cohort_attribute ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.value_as_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cohort_attribute'
 where ev.value_as_concept_id <> 0
 group by ev.value_as_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2802,7 +2802,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_cohort_attribute
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_cohort_attribute
 SELECT
     'value_as_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2811,8 +2811,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_cohort_attribute ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_cohort_attribute ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_cohort_attribute'
 where ev.value_as_concept_id = 0
 group by ev.value_as_concept_id, tt.count
@@ -2820,8 +2820,8 @@ order by count desc
 limit 100
 ;
 
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_top_cdm_metadata;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_metadata
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_top_cdm_metadata;
+CREATE TABLE @metrics_project.@metrics_dataset.me_top_cdm_metadata
 (
     concept_field     STRING,
     category          STRING,
@@ -2832,7 +2832,7 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_top_cdm_metadata
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_metadata
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_metadata
 SELECT
     'metadata_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2841,10 +2841,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_metadata ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_metadata ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.metadata_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_metadata'
 where ev.metadata_concept_id <> 0
 group by ev.metadata_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2852,7 +2852,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_metadata
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_metadata
 SELECT
     'metadata_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2861,8 +2861,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_metadata ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_metadata ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_metadata'
 where ev.metadata_concept_id = 0
 group by ev.metadata_concept_id, tt.count
@@ -2870,7 +2870,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_metadata
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_metadata
 SELECT
     'metadata_type_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2879,10 +2879,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_metadata ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_metadata ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.metadata_type_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_metadata'
 where ev.metadata_type_concept_id <> 0
 group by ev.metadata_type_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2890,7 +2890,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_metadata
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_metadata
 SELECT
     'metadata_type_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2899,8 +2899,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_metadata ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_metadata ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_metadata'
 where ev.metadata_type_concept_id = 0
 group by ev.metadata_type_concept_id, tt.count
@@ -2908,7 +2908,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_metadata
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_metadata
 SELECT
     'value_as_concept_id'     AS concept_field,
     'Mapped'              AS category,
@@ -2917,10 +2917,10 @@ SELECT
     vc.concept_name         AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_metadata ev
-inner join `@etl_project`.@etl_dataset.voc_concept vc
+from @etl_project.@etl_dataset.cdm_metadata ev
+inner join @etl_project.@etl_dataset.voc_concept vc
     on ev.value_as_concept_id = vc.concept_id
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_metadata'
 where ev.value_as_concept_id <> 0
 group by ev.value_as_concept_id, vc.concept_id, vc.concept_name, tt.count
@@ -2928,7 +2928,7 @@ order by count desc
 limit 100
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_metadata
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_metadata
 SELECT
     'value_as_concept_id'      AS concept_field,
     'Unmapped'            AS category,
@@ -2937,8 +2937,8 @@ SELECT
     CAST(NULL AS STRING)    AS concept_name,
     COUNT(*)                AS count,
     ROUND(CAST(count(*) AS FLOAT64) / tt.count * 100, 2) AS percent
-from `@etl_project`.@etl_dataset.cdm_metadata ev
-inner join `@metrics_project`.@metrics_dataset.me_total tt
+from @etl_project.@etl_dataset.cdm_metadata ev
+inner join @metrics_project.@metrics_dataset.me_total tt
     on tt.table_name = 'cdm_metadata'
 where ev.value_as_concept_id = 0
 group by ev.value_as_concept_id, tt.count

--- a/test/metrics_gen/me_tops_together_from_conf.sql
+++ b/test/metrics_gen/me_tops_together_from_conf.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_tops_together;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_tops_together
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_tops_together;
+CREATE TABLE @metrics_project.@metrics_dataset.me_tops_together
 (
     table_name        STRING,
     concept_field     STRING,
@@ -11,195 +11,195 @@ CREATE TABLE `@metrics_project`.@metrics_dataset.me_tops_together
     percent           FLOAT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_care_site'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_care_site rt
+from @metrics_project.@metrics_dataset.me_top_cdm_care_site rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_provider'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_provider rt
+from @metrics_project.@metrics_dataset.me_top_cdm_provider rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_person'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_person rt
+from @metrics_project.@metrics_dataset.me_top_cdm_person rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_death'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_death rt
+from @metrics_project.@metrics_dataset.me_top_cdm_death rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_observation_period'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_observation_period rt
+from @metrics_project.@metrics_dataset.me_top_cdm_observation_period rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_payer_plan_period'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_payer_plan_period rt
+from @metrics_project.@metrics_dataset.me_top_cdm_payer_plan_period rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_visit_occurrence'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_visit_occurrence rt
+from @metrics_project.@metrics_dataset.me_top_cdm_visit_occurrence rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_visit_detail'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_visit_detail rt
+from @metrics_project.@metrics_dataset.me_top_cdm_visit_detail rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_condition_occurrence'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_condition_occurrence rt
+from @metrics_project.@metrics_dataset.me_top_cdm_condition_occurrence rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_procedure_occurrence'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_procedure_occurrence rt
+from @metrics_project.@metrics_dataset.me_top_cdm_procedure_occurrence rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_observation'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_observation rt
+from @metrics_project.@metrics_dataset.me_top_cdm_observation rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_measurement'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_measurement rt
+from @metrics_project.@metrics_dataset.me_top_cdm_measurement rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_device_exposure'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_device_exposure rt
+from @metrics_project.@metrics_dataset.me_top_cdm_device_exposure rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_drug_exposure'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_drug_exposure rt
+from @metrics_project.@metrics_dataset.me_top_cdm_drug_exposure rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_cost'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_cost rt
+from @metrics_project.@metrics_dataset.me_top_cdm_cost rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_condition_era'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_condition_era rt
+from @metrics_project.@metrics_dataset.me_top_cdm_condition_era rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_drug_era'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_drug_era rt
+from @metrics_project.@metrics_dataset.me_top_cdm_drug_era rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_dose_era'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_dose_era rt
+from @metrics_project.@metrics_dataset.me_top_cdm_dose_era rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_specimen'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_specimen rt
+from @metrics_project.@metrics_dataset.me_top_cdm_specimen rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_note'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_note rt
+from @metrics_project.@metrics_dataset.me_top_cdm_note rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_note_nlp'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_note_nlp rt
+from @metrics_project.@metrics_dataset.me_top_cdm_note_nlp rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_fact_relationship'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_fact_relationship rt
+from @metrics_project.@metrics_dataset.me_top_cdm_fact_relationship rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_cohort_attribute'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_cohort_attribute rt
+from @metrics_project.@metrics_dataset.me_top_cdm_cohort_attribute rt
 order by concept_field, category, count desc
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_metadata'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_metadata rt
+from @metrics_project.@metrics_dataset.me_top_cdm_metadata rt
 order by concept_field, category, count desc
 ;
 

--- a/test/metrics_gen/me_totals_from_conf.sql
+++ b/test/metrics_gen/me_totals_from_conf.sql
@@ -1,175 +1,175 @@
-DROP TABLE IF EXISTS `@metrics_project`.@metrics_dataset.me_total;
-CREATE TABLE `@metrics_project`.@metrics_dataset.me_total
+DROP TABLE IF EXISTS @metrics_project.@metrics_dataset.me_total;
+CREATE TABLE @metrics_project.@metrics_dataset.me_total
 (
     table_name        STRING,
     count             INT64
 );
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_care_site'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_care_site ev
+from @etl_project.@etl_dataset.cdm_care_site ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_provider'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_provider ev
+from @etl_project.@etl_dataset.cdm_provider ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_person'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_person ev
+from @etl_project.@etl_dataset.cdm_person ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_death'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_death ev
+from @etl_project.@etl_dataset.cdm_death ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_observation_period'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_observation_period ev
+from @etl_project.@etl_dataset.cdm_observation_period ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_payer_plan_period'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_payer_plan_period ev
+from @etl_project.@etl_dataset.cdm_payer_plan_period ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_visit_occurrence'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_visit_occurrence ev
+from @etl_project.@etl_dataset.cdm_visit_occurrence ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_visit_detail'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_visit_detail ev
+from @etl_project.@etl_dataset.cdm_visit_detail ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_condition_occurrence'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_condition_occurrence ev
+from @etl_project.@etl_dataset.cdm_condition_occurrence ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_procedure_occurrence'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_procedure_occurrence ev
+from @etl_project.@etl_dataset.cdm_procedure_occurrence ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_observation'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_observation ev
+from @etl_project.@etl_dataset.cdm_observation ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_measurement'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_measurement ev
+from @etl_project.@etl_dataset.cdm_measurement ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_device_exposure'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_device_exposure ev
+from @etl_project.@etl_dataset.cdm_device_exposure ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_drug_exposure'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_drug_exposure ev
+from @etl_project.@etl_dataset.cdm_drug_exposure ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_cost'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_cost ev
+from @etl_project.@etl_dataset.cdm_cost ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_condition_era'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_condition_era ev
+from @etl_project.@etl_dataset.cdm_condition_era ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_drug_era'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_drug_era ev
+from @etl_project.@etl_dataset.cdm_drug_era ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_dose_era'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_dose_era ev
+from @etl_project.@etl_dataset.cdm_dose_era ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_specimen'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_specimen ev
+from @etl_project.@etl_dataset.cdm_specimen ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_note'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_note ev
+from @etl_project.@etl_dataset.cdm_note ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_note_nlp'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_note_nlp ev
+from @etl_project.@etl_dataset.cdm_note_nlp ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_fact_relationship'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_fact_relationship ev
+from @etl_project.@etl_dataset.cdm_fact_relationship ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_cohort_attribute'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_cohort_attribute ev
+from @etl_project.@etl_dataset.cdm_cohort_attribute ev
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_total
+INSERT INTO @metrics_project.@metrics_dataset.me_total
 SELECT
     'cdm_metadata'     AS table_name,
     COUNT(*)             AS count
-from `@etl_project`.@etl_dataset.cdm_metadata ev
+from @etl_project.@etl_dataset.cdm_metadata ev
 ;
 

--- a/test/metrics_gen/tmp_top100.sql
+++ b/test/metrics_gen/tmp_top100.sql
@@ -1,7 +1,7 @@
 
 
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_top_cdm_measurement
+INSERT INTO @metrics_project.@metrics_dataset.me_top_cdm_measurement
 SELECT
     'unit_concept_id'     AS concept_field,
     IF(vc.concept_id IS NOT NULL, 'Mapped', 'Unmapped') AS category,
@@ -13,8 +13,8 @@ SELECT
             COUNT(IF(ev.unit_concept_id <> 0, 1, NULL)) 
         AS FLOAT64) / COUNT(*) * 100, 2) AS percent,
     1111111111111 AS is_top
-FROM `@etl_project`.@etl_dataset.cdm_measurement ev
-LEFT JOIN `@etl_project`.@etl_dataset.voc_concept vc
+FROM @etl_project.@etl_dataset.cdm_measurement ev
+LEFT JOIN @etl_project.@etl_dataset.voc_concept vc
     ON ev.unit_concept_id = vc.concept_id
 WHERE ev.unit_concept_id IS NOT NULL
 GROUP BY ev.unit_source_value, vc.concept_id, vc.concept_name
@@ -23,11 +23,11 @@ ORDER BY category, count DESC
 ;
 
 
-INSERT INTO `@metrics_project`.@metrics_dataset.me_tops_together
+INSERT INTO @metrics_project.@metrics_dataset.me_tops_together
 SELECT
     'cdm_measurement'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_measurement rt
+from @metrics_project.@metrics_dataset.me_top_cdm_measurement rt
 WHERE rt.category = 'Mapped'
 order by count desc
 LIMIT 100
@@ -35,7 +35,7 @@ UNION ALL
 SELECT
     'cdm_measurement'      AS table_name,
     *
-from `@metrics_project`.@metrics_dataset.me_top_cdm_measurement rt
+from @metrics_project.@metrics_dataset.me_top_cdm_measurement rt
 WHERE rt.category = 'Unmapped'
 order by count desc
 LIMIT 100

--- a/test/qa/metric_total_row_count.sql
+++ b/test/qa/metric_total_row_count.sql
@@ -19,7 +19,7 @@
 --      table_id || unit_id
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@metrics_project`.@metrics_dataset.report_qa_row_count AS
+CREATE OR REPLACE TABLE @metrics_project.@metrics_dataset.report_qa_row_count AS
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -33,7 +33,7 @@ SELECT
 -- src_patients
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -42,14 +42,14 @@ SELECT
     'person.patients'                   AS unit_id,
     COUNT(*)                            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.src_patients
+    @etl_project.@etl_dataset.src_patients
 ;
 
 -- -------------------------------------------------------------------
 -- cdm_person
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -58,14 +58,14 @@ SELECT
     'person.patients'                   AS unit_id,
     COUNT(*)                            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.cdm_person
+    @etl_project.@etl_dataset.cdm_person
 ;
 
 -- -------------------------------------------------------------------
 -- src_transfers (careunit)
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -74,14 +74,14 @@ SELECT
     'care_site.transfers'               AS unit_id,
     COUNT(DISTINCT careunit)            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.src_transfers
+    @etl_project.@etl_dataset.src_transfers
 ;
 
 -- -------------------------------------------------------------------
 -- cdm_care_site
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -90,14 +90,14 @@ SELECT
     'care_site.transfers'               AS unit_id,
     COUNT(*)                            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.cdm_care_site
+    @etl_project.@etl_dataset.cdm_care_site
 ;
 
 -- -------------------------------------------------------------------
 -- cdm_visit_occurrence
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -106,14 +106,14 @@ SELECT
     'visit.admissions'                  AS unit_id,
     COUNT(*)                            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence
+    @etl_project.@etl_dataset.cdm_visit_occurrence
 ;
 
 -- -------------------------------------------------------------------
 -- src_admissions
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -122,14 +122,14 @@ SELECT
     'visit.admissions'                  AS unit_id,
     COUNT(*)                            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.src_admissions
+    @etl_project.@etl_dataset.src_admissions
 ;
 
 -- -------------------------------------------------------------------
 -- cdm_visit_detail
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -138,7 +138,7 @@ SELECT
     unit_id                             AS unit_id,
     COUNT(*)                            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail
+    @etl_project.@etl_dataset.cdm_visit_detail
 GROUP BY
     unit_id
 ;
@@ -147,7 +147,7 @@ GROUP BY
 -- src_diagnoses_icd
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -156,14 +156,14 @@ SELECT
     'condition.diagnoses_icd'           AS unit_id,
     COUNT(*)                            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.src_diagnoses_icd
+    @etl_project.@etl_dataset.src_diagnoses_icd
 ;
 
 -- -------------------------------------------------------------------
 -- cdm_condition_occurrence
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_row_count
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_row_count
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -172,7 +172,7 @@ SELECT
     unit_id                             AS unit_id,
     COUNT(*)                            AS row_count
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence
+    @etl_project.@etl_dataset.cdm_condition_occurrence
 GROUP BY
     unit_id
 ;

--- a/test/qa/qa_care_site.sql
+++ b/test/qa/qa_care_site.sql
@@ -11,7 +11,7 @@
 -- count (count by trace_id?)
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_test
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_test
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -25,7 +25,7 @@ FROM
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'src_transfers'
         AND unit_id = 'care_site.transfers'
@@ -34,7 +34,7 @@ LEFT JOIN
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'cdm_care_site'
 ) cdm

--- a/test/qa/qa_condition_occurrence.sql
+++ b/test/qa/qa_condition_occurrence.sql
@@ -11,7 +11,7 @@
 -- count (count by trace_id?)
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_test
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_test
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -25,7 +25,7 @@ FROM
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'src_diagnoses_icd'
 ) src
@@ -33,7 +33,7 @@ LEFT JOIN
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'cdm_condition_occurrence'
 ) cdm

--- a/test/qa/qa_person.sql
+++ b/test/qa/qa_person.sql
@@ -11,7 +11,7 @@
 -- count (count by trace_id?)
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_test
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_test
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -25,7 +25,7 @@ FROM
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'src_patients'
 ) src
@@ -33,7 +33,7 @@ LEFT JOIN
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'cdm_person'
 ) cdm

--- a/test/qa/qa_start.sql
+++ b/test/qa/qa_start.sql
@@ -13,7 +13,7 @@
 -- QA tests report table
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@metrics_project`.@metrics_dataset.report_qa_test AS
+CREATE OR REPLACE TABLE @metrics_project.@metrics_dataset.report_qa_test AS
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS

--- a/test/qa/qa_visit_detail.sql
+++ b/test/qa/qa_visit_detail.sql
@@ -15,7 +15,7 @@
 -- Rule 1, visit_detail.transfers
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_test
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_test
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -31,7 +31,7 @@ FROM
         'visit_detail.transfers'    AS unit_id,
         COUNT(*)                    AS row_count
     FROM
-        `@etl_project`.@etl_dataset.src_transfers tr
+        @etl_project.@etl_dataset.src_transfers tr
     WHERE 
         tr.eventtype != 'discharge' -- these are not useful
 ) src
@@ -39,7 +39,7 @@ LEFT JOIN
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'cdm_visit_detail'
         AND unit_id = 'visit_detail.transfers'
@@ -51,7 +51,7 @@ LEFT JOIN
 -- Rule 2, visit_detail.admissions
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_test
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_test
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -67,7 +67,7 @@ FROM
         'visit_detail.admissions'    AS unit_id,
         COUNT(*)                    AS row_count
     FROM 
-        `@etl_project`.@etl_dataset.src_admissions adm
+        @etl_project.@etl_dataset.src_admissions adm
     WHERE 
         adm.edregtime IS NOT NULL -- only those having a emergency timestamped
 ) src
@@ -75,7 +75,7 @@ LEFT JOIN
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'cdm_visit_detail'
         AND unit_id = 'visit_detail.admissions'
@@ -87,7 +87,7 @@ LEFT JOIN
 -- Rule 3, visit_detail.services
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_test
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_test
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -103,9 +103,9 @@ FROM
         'visit_detail.services'     AS unit_id,
         COUNT(*)                    AS row_count
     FROM 
-        `@etl_project`.@etl_dataset.src_services src
+        @etl_project.@etl_dataset.src_services src
     INNER JOIN 
-        `@etl_project`.@etl_dataset.cdm_visit_occurrence vis 
+        @etl_project.@etl_dataset.cdm_visit_occurrence vis 
         ON  vis.visit_source_value = 
             CONCAT(CAST(src.subject_id AS STRING), '|', COALESCE(CAST(src.hadm_id AS STRING), 'None'))
 ) src
@@ -113,7 +113,7 @@ LEFT JOIN
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'cdm_visit_detail'
         AND unit_id = 'visit_detail.services'

--- a/test/qa/qa_visit_occurrence.sql
+++ b/test/qa/qa_visit_occurrence.sql
@@ -11,7 +11,7 @@
 -- count (count by trace_id?)
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_qa_test
+INSERT INTO @metrics_project.@metrics_dataset.report_qa_test
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -25,7 +25,7 @@ FROM
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'src_admissions'
 ) src
@@ -33,7 +33,7 @@ LEFT JOIN
 (
     SELECT unit_id, row_count
     FROM
-        `@metrics_project`.@metrics_dataset.report_qa_row_count
+        @metrics_project.@metrics_dataset.report_qa_row_count
     WHERE
         table_id = 'cdm_visit_occurrence'
 ) cdm

--- a/test/ut/ut_basic_gen.sql
+++ b/test/ut/ut_basic_gen.sql
@@ -14,7 +14,7 @@
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -24,7 +24,7 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(care_site_id) - COUNT(DISTINCT care_site_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_care_site
+    @etl_project.@etl_dataset.cdm_care_site
 ;
 
 -- -------------------------------------------------------------------
@@ -37,7 +37,7 @@ FROM
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -47,7 +47,7 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(person_id) - COUNT(DISTINCT person_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_person
+    @etl_project.@etl_dataset.cdm_person
 ;
 
 -- -------------------------------------------------------------------
@@ -60,7 +60,7 @@ FROM
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -70,14 +70,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(person_id) - COUNT(DISTINCT person_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_death
+    @etl_project.@etl_dataset.cdm_death
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -87,9 +87,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_death cdm
+    @etl_project.@etl_dataset.cdm_death cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
@@ -105,7 +105,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -115,14 +115,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(observation_period_id) - COUNT(DISTINCT observation_period_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_observation_period
+    @etl_project.@etl_dataset.cdm_observation_period
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -132,9 +132,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_observation_period cdm
+    @etl_project.@etl_dataset.cdm_observation_period cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
@@ -150,7 +150,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -160,7 +160,7 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(visit_occurrence_id) - COUNT(DISTINCT visit_occurrence_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence
+    @etl_project.@etl_dataset.cdm_visit_occurrence
 ;
 
 
@@ -168,7 +168,7 @@ FROM
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -178,14 +178,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(visit_source_value) - COUNT(DISTINCT visit_source_value) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence
+    @etl_project.@etl_dataset.cdm_visit_occurrence
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -195,19 +195,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence cdm
+    @etl_project.@etl_dataset.cdm_visit_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -217,9 +217,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.preceding_visit_occurrence_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence cdm
+    @etl_project.@etl_dataset.cdm_visit_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.preceding_visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL -- FK target
@@ -235,7 +235,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -245,7 +245,7 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(visit_detail_id) - COUNT(DISTINCT visit_detail_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail
+    @etl_project.@etl_dataset.cdm_visit_detail
 ;
 
 
@@ -253,7 +253,7 @@ FROM
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -263,14 +263,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(visit_detail_source_value) - COUNT(DISTINCT visit_detail_source_value) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail
+    @etl_project.@etl_dataset.cdm_visit_detail
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -280,19 +280,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -302,19 +302,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.visit_occurrence_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_detail.visit_detail_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_detail.visit_detail_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -324,9 +324,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.preceding_visit_detail_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_detail fk
+    @etl_project.@etl_dataset.cdm_visit_detail fk
         ON cdm.preceding_visit_detail_id = fk.visit_detail_id
 WHERE
     fk.visit_detail_id IS NULL -- FK target
@@ -342,7 +342,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -352,14 +352,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(condition_occurrence_id) - COUNT(DISTINCT condition_occurrence_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence
+    @etl_project.@etl_dataset.cdm_condition_occurrence
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -369,19 +369,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence cdm
+    @etl_project.@etl_dataset.cdm_condition_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -391,9 +391,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.visit_occurrence_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence cdm
+    @etl_project.@etl_dataset.cdm_condition_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL -- FK target
@@ -409,7 +409,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -419,14 +419,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(procedure_occurrence_id) - COUNT(DISTINCT procedure_occurrence_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_procedure_occurrence
+    @etl_project.@etl_dataset.cdm_procedure_occurrence
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -436,19 +436,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_procedure_occurrence cdm
+    @etl_project.@etl_dataset.cdm_procedure_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -458,9 +458,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.visit_occurrence_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_procedure_occurrence cdm
+    @etl_project.@etl_dataset.cdm_procedure_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL -- FK target
@@ -476,7 +476,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -486,14 +486,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(observation_id) - COUNT(DISTINCT observation_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_observation
+    @etl_project.@etl_dataset.cdm_observation
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -503,19 +503,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_observation cdm
+    @etl_project.@etl_dataset.cdm_observation cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -525,9 +525,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.visit_occurrence_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_observation cdm
+    @etl_project.@etl_dataset.cdm_observation cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL -- FK target
@@ -543,7 +543,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -553,14 +553,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(measurement_id) - COUNT(DISTINCT measurement_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_measurement
+    @etl_project.@etl_dataset.cdm_measurement
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -570,19 +570,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_measurement cdm
+    @etl_project.@etl_dataset.cdm_measurement cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -592,9 +592,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.visit_occurrence_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_measurement cdm
+    @etl_project.@etl_dataset.cdm_measurement cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL -- FK target
@@ -610,7 +610,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -620,14 +620,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(device_exposure_id) - COUNT(DISTINCT device_exposure_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_device_exposure
+    @etl_project.@etl_dataset.cdm_device_exposure
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -637,19 +637,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_device_exposure cdm
+    @etl_project.@etl_dataset.cdm_device_exposure cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -659,9 +659,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.visit_occurrence_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_device_exposure cdm
+    @etl_project.@etl_dataset.cdm_device_exposure cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL -- FK target
@@ -677,7 +677,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -687,14 +687,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(drug_exposure_id) - COUNT(DISTINCT drug_exposure_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_drug_exposure
+    @etl_project.@etl_dataset.cdm_drug_exposure
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -704,19 +704,19 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_drug_exposure cdm
+    @etl_project.@etl_dataset.cdm_drug_exposure cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
+-- FK to @etl_project.@etl_dataset.cdm_visit_occurrence.visit_occurrence_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -726,9 +726,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.visit_occurrence_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_drug_exposure cdm
+    @etl_project.@etl_dataset.cdm_drug_exposure cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL -- FK target
@@ -744,7 +744,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -754,14 +754,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(condition_era_id) - COUNT(DISTINCT condition_era_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_era
+    @etl_project.@etl_dataset.cdm_condition_era
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -771,9 +771,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_era cdm
+    @etl_project.@etl_dataset.cdm_condition_era cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
@@ -789,7 +789,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -799,14 +799,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(drug_era_id) - COUNT(DISTINCT drug_era_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_drug_era
+    @etl_project.@etl_dataset.cdm_drug_era
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -816,9 +816,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_drug_era cdm
+    @etl_project.@etl_dataset.cdm_drug_era cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
@@ -834,7 +834,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -844,14 +844,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(dose_era_id) - COUNT(DISTINCT dose_era_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_dose_era
+    @etl_project.@etl_dataset.cdm_dose_era
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -861,9 +861,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_dose_era cdm
+    @etl_project.@etl_dataset.cdm_dose_era cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
@@ -879,7 +879,7 @@ WHERE
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -889,14 +889,14 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(specimen_id) - COUNT(DISTINCT specimen_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_specimen
+    @etl_project.@etl_dataset.cdm_specimen
 ;
 
 -- -------------------------------------------------------------------
--- FK to `@etl_project`.@etl_dataset.cdm_person.person_id
+-- FK to @etl_project.@etl_dataset.cdm_person.person_id
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -906,9 +906,9 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_specimen cdm
+    @etl_project.@etl_dataset.cdm_specimen cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target

--- a/test/ut/ut_care_site.sql
+++ b/test/ut/ut_care_site.sql
@@ -11,7 +11,7 @@
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -21,10 +21,10 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(care_site_id) - COUNT(DISTINCT care_site_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_care_site
+    @etl_project.@etl_dataset.cdm_care_site
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -34,7 +34,7 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(care_site_source_value) - COUNT(DISTINCT care_site_source_value) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_care_site
+    @etl_project.@etl_dataset.cdm_care_site
 ;
 
 -- -------------------------------------------------------------------
@@ -46,7 +46,7 @@ FROM
 --      allows 0?
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -56,9 +56,9 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_care_site cdm
+    @etl_project.@etl_dataset.cdm_care_site cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.place_of_service_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE

--- a/test/ut/ut_condition_occurrence.sql
+++ b/test/ut/ut_condition_occurrence.sql
@@ -11,7 +11,7 @@
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -21,7 +21,7 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(condition_occurrence_id) - COUNT(DISTINCT condition_occurrence_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence
+    @etl_project.@etl_dataset.cdm_condition_occurrence
 ;
 
 -- -------------------------------------------------------------------
@@ -37,7 +37,7 @@ FROM
 --      allows 0?
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -51,9 +51,9 @@ SELECT
     ))                                  AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence cdm
+    @etl_project.@etl_dataset.cdm_condition_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.condition_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
         AND vc.vocabulary_id IN ('ICD9CM', 'ICD10CM')
@@ -71,7 +71,7 @@ WHERE
 -- start time should be not later than end time
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -81,12 +81,12 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence
+    @etl_project.@etl_dataset.cdm_condition_occurrence
 WHERE
     condition_start_date > COALESCE(condition_end_date, PARSE_DATE('%Y-%m-%d','2099-12-31'))
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -96,7 +96,7 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence
+    @etl_project.@etl_dataset.cdm_condition_occurrence
 WHERE
     condition_start_datetime > COALESCE(condition_end_datetime, PARSE_DATETIME('%F','2099-12-31'))
 ;
@@ -105,7 +105,7 @@ WHERE
 -- foreign key
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -115,16 +115,16 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) = 0)                      AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence cdm
+    @etl_project.@etl_dataset.cdm_condition_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     -- cdm.person_id -- required = true
     fk.person_id IS NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -134,16 +134,16 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) = 0)                      AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence cdm
+    @etl_project.@etl_dataset.cdm_condition_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     cdm.visit_occurrence_id IS NOT NULL -- required = false
     AND fk.visit_occurrence_id IS NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -155,8 +155,8 @@ SELECT
     ))                                  AS condition_json,
     (COUNT(*) = 0)                      AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_condition_occurrence cdm
+    @etl_project.@etl_dataset.cdm_condition_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.src_diagnoses_icd fk
+    @etl_project.@etl_dataset.src_diagnoses_icd fk
         ON cdm.condition_source_value = fk.icd_code
 ;

--- a/test/ut/ut_death.sql
+++ b/test/ut/ut_death.sql
@@ -11,7 +11,7 @@
 -- FK to `@source_project`.@core_dataset.admissions.deathtime
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -21,7 +21,7 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.death_date) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_death cdm
+    @etl_project.@etl_dataset.cdm_death cdm
 LEFT JOIN
 (
     SELECT deathtime FROM `@source_project`.@core_dataset.admissions

--- a/test/ut/ut_person.sql
+++ b/test/ut/ut_person.sql
@@ -11,7 +11,7 @@
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -21,10 +21,10 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(person_id) - COUNT(DISTINCT person_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_person
+    @etl_project.@etl_dataset.cdm_person
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -34,7 +34,7 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(person_source_value) - COUNT(DISTINCT person_source_value) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_person
+    @etl_project.@etl_dataset.cdm_person
 ;
 
 -- -------------------------------------------------------------------
@@ -46,7 +46,7 @@ FROM
 --      allows 0?
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -56,16 +56,16 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_person cdm
+    @etl_project.@etl_dataset.cdm_person cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.gender_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE
     cdm.gender_concept_id <> 0
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -75,16 +75,16 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_person cdm
+    @etl_project.@etl_dataset.cdm_person cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.race_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE
     cdm.race_concept_id <> 0
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -94,9 +94,9 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_person cdm
+    @etl_project.@etl_dataset.cdm_person cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.ethnicity_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE

--- a/test/ut/ut_start.sql
+++ b/test/ut/ut_start.sql
@@ -13,7 +13,7 @@
 -- Unit tests report table
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@metrics_project`.@metrics_dataset.report_unit_test AS
+CREATE OR REPLACE TABLE @metrics_project.@metrics_dataset.report_unit_test AS
 SELECT
     CAST(NULL AS STRING)                AS report_id, -- task_id, run_id, target_dataset etc.
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS

--- a/test/ut/ut_templates.sql
+++ b/test/ut/ut_templates.sql
@@ -11,7 +11,7 @@
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -21,7 +21,7 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT({table_name}_id) - COUNT(DISTINCT {table_name}_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_{table_name}
+    @etl_project.@etl_dataset.cdm_{table_name}
 ;
 
 -- -------------------------------------------------------------------
@@ -37,7 +37,7 @@ FROM
 --      allows 0?
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -50,9 +50,9 @@ SELECT
     ))                                  AS criteria_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_{table_name} cdm
+    @etl_project.@etl_dataset.cdm_{table_name} cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.{domain_id}_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
         AND vc.domain_id = '{domain_id}' -- Aaaaaa
@@ -69,7 +69,7 @@ WHERE
 -- start time should be not later than end time
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -79,12 +79,12 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(*) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_{table_name}
+    @etl_project.@etl_dataset.cdm_{table_name}
 WHERE
     {date_prefix}_start_date > COALESCE({date_prefix}_end_date, PARSE_DATE('%Y-%m-%d','2099-12-31'))
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -94,7 +94,7 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(*) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_{table_name}
+    @etl_project.@etl_dataset.cdm_{table_name}
 WHERE
     {date_prefix}_start_datetime > COALESCE({date_prefix}_end_datetime, PARSE_DATETIME('%F','2099-12-31'))
 ;
@@ -103,7 +103,7 @@ WHERE
 -- foreign key
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -113,15 +113,15 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed -- FK source
 FROM
-    `@etl_project`.@etl_dataset.cdm_{table_name} cdm
+    @etl_project.@etl_dataset.cdm_{table_name} cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL -- FK target
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -131,15 +131,15 @@ SELECT
     CAST(NULL AS STRING)                AS criteria_json,
     (COUNT(cdm.visit_occurrence_id) = 0)        AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_{table_name} cdm
+    @etl_project.@etl_dataset.cdm_{table_name} cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -151,9 +151,9 @@ SELECT
     ))                                  AS criteria_json,
     (COUNT(cdm.{source_value_prefix}_source_value) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_{table_name} cdm
+    @etl_project.@etl_dataset.cdm_{table_name} cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.src_diagnoses_icd fk
+    @etl_project.@etl_dataset.src_diagnoses_icd fk
         ON cdm.{source_value_prefix}_source_value = fk.icd_code
 WHERE
     fk.icd_code IS NULL

--- a/test/ut/ut_visit_detail.sql
+++ b/test/ut/ut_visit_detail.sql
@@ -11,7 +11,7 @@
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -21,10 +21,10 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(visit_detail_id) - COUNT(DISTINCT visit_detail_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail
+    @etl_project.@etl_dataset.cdm_visit_detail
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -34,7 +34,7 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(visit_detail_source_value) - COUNT(DISTINCT visit_detail_source_value) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail
+    @etl_project.@etl_dataset.cdm_visit_detail
 ;
 
 -- -------------------------------------------------------------------
@@ -46,7 +46,7 @@ FROM
 --      allows 0?
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -56,16 +56,16 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.visit_detail_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE
     cdm.visit_detail_concept_id <> 0
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -75,16 +75,16 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.visit_detail_type_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE
     cdm.visit_detail_type_concept_id <> 0
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -94,16 +94,16 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.admitting_source_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE
     cdm.admitting_source_concept_id <> 0
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -113,9 +113,9 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.discharge_to_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE
@@ -138,7 +138,7 @@ WHERE
 -- foreign key
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -148,15 +148,15 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(cdm.person_id) = 0)          AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 WHERE
     fk.person_id IS NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -166,15 +166,15 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(cdm.preceding_visit_detail_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_detail fk
+    @etl_project.@etl_dataset.cdm_visit_detail fk
         ON cdm.preceding_visit_detail_id = fk.visit_detail_id
 WHERE
     fk.visit_detail_id IS NULL
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -184,9 +184,9 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(cdm.visit_occurrence_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_detail cdm
+    @etl_project.@etl_dataset.cdm_visit_detail cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     fk.visit_occurrence_id IS NULL

--- a/test/ut/ut_visit_occurrence.sql
+++ b/test/ut/ut_visit_occurrence.sql
@@ -11,7 +11,7 @@
 -- unique
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -21,10 +21,10 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(visit_occurrence_id) - COUNT(DISTINCT visit_occurrence_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence
+    @etl_project.@etl_dataset.cdm_visit_occurrence
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -34,7 +34,7 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(visit_source_value) - COUNT(DISTINCT visit_source_value) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence
+    @etl_project.@etl_dataset.cdm_visit_occurrence
 ;
 
 -- -------------------------------------------------------------------
@@ -46,7 +46,7 @@ FROM
 --      allows 0?
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -56,9 +56,9 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) > 0 AND COUNT(*) - COUNT(vc.concept_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence cdm
+    @etl_project.@etl_dataset.cdm_visit_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.voc_concept vc
+    @etl_project.@etl_dataset.voc_concept vc
         ON cdm.visit_concept_id = vc.concept_id
         AND vc.standard_concept = 'S'
 WHERE
@@ -81,7 +81,7 @@ WHERE
 -- foreign key
 -- -------------------------------------------------------------------
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -91,13 +91,13 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) - COUNT(fk.person_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence cdm
+    @etl_project.@etl_dataset.cdm_visit_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_person fk
+    @etl_project.@etl_dataset.cdm_person fk
         ON cdm.person_id = fk.person_id
 ;
 
-INSERT INTO `@metrics_project`.@metrics_dataset.report_unit_test
+INSERT INTO @metrics_project.@metrics_dataset.report_unit_test
 SELECT
     CAST(NULL AS STRING)                AS report_id,
     FORMAT_DATETIME('%Y-%m-%d %X', CURRENT_DATETIME()) AS report_starttime, -- X = HH:MM:SS
@@ -107,9 +107,9 @@ SELECT
     CAST(NULL AS STRING)                AS condition_json,
     (COUNT(*) - COUNT(fk.person_id) = 0) AS test_passed
 FROM
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence cdm
+    @etl_project.@etl_dataset.cdm_visit_occurrence cdm
 LEFT JOIN
-    `@etl_project`.@etl_dataset.cdm_visit_occurrence fk
+    @etl_project.@etl_dataset.cdm_visit_occurrence fk
         ON cdm.preceding_visit_occurrence_id = fk.visit_occurrence_id
 WHERE
     cdm.preceding_visit_occurrence_id IS NOT NULL

--- a/vocabulary_refresh/check_custom_loaded.sql
+++ b/vocabulary_refresh/check_custom_loaded.sql
@@ -8,88 +8,88 @@
     Check loaded tmp_custom_mapping
 */
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 (
     field_name  STRING,
     cnt_empty   INT64
 );
 
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'concept_name' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE concept_name IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'source_concept_id' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE source_concept_id IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'source_vocabulary_id' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE source_vocabulary_id IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'source_domain_id' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE source_domain_id IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'source_concept_class_id' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE source_concept_class_id IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'concept_code' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE concept_code IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'valid_start_date' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE valid_start_date IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'valid_end_date' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE valid_end_date IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'target_concept_id' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE target_concept_id IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'relationship_id' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE relationship_id IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'reverese_relationship_id' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE reverese_relationship_id IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'relationship_valid_start_date' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE relationship_valid_start_date IS NULL;
  
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'relationship_end_date' AS field_name, COUNT(*) as cnt_empty 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
 WHERE relationship_end_date IS NULL;
 
-INSERT INTO `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+INSERT INTO @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 SELECT 'duplicate_source_concept_id' AS field_name, COUNT(*) as cnt_empty 
 FROM (
     SELECT source_concept_id
-    FROM `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping
+    FROM @bq_target_project.@bq_target_dataset.tmp_custom_mapping
     GROUP BY source_concept_id
     HAVING COUNT(*) > 1
 ) t;
 
 SELECT
     field_name, cnt_empty
-FROM `@bq_target_project.@bq_target_dataset`.z_check_tmp_custom_mapping
+FROM @bq_target_project.@bq_target_dataset.z_check_tmp_custom_mapping
 ORDER BY field_name
 ;

--- a/vocabulary_refresh/create_voc_from_tmp.sql
+++ b/vocabulary_refresh/create_voc_from_tmp.sql
@@ -21,7 +21,7 @@
 -- concept
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.concept AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.concept AS
 SELECT
     concept_id,
     concept_name,
@@ -36,17 +36,17 @@ SELECT
     'concept' AS load_table_id,
     FARM_FINGERPRINT(GENERATE_UUID()) AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_concept
+    @bq_target_project.@bq_target_dataset.tmp_concept
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_concept
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_concept
 ;
 
 -- ------------------------------------------------------------------------------
 -- concept_relationship
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.concept_relationship AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.concept_relationship AS
 SELECT
     concept_id_1,
     concept_id_2,
@@ -57,26 +57,26 @@ SELECT
     'concept_relationship' AS load_table_id,
     0 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_concept_relationship
+    @bq_target_project.@bq_target_dataset.tmp_concept_relationship
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_concept_relationship
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_concept_relationship
 ;
 
 -- ------------------------------------------------------------------------------
 -- vocabulary
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.vocabulary AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.vocabulary AS
 SELECT
     *,
     'vocabulary' AS load_table_id,
     0 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_vocabulary
+    @bq_target_project.@bq_target_dataset.tmp_vocabulary
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_vocabulary
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_vocabulary
 ;
 
 -- ------------------------------------------------------------------------------
@@ -87,7 +87,7 @@ DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_vocabulary
 -- drug_strength
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.drug_strength AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.drug_strength AS
 SELECT
     drug_concept_id,
     ingredient_concept_id,
@@ -104,89 +104,89 @@ SELECT
     'drug_strength' AS load_table_id,
     0 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_drug_strength
+    @bq_target_project.@bq_target_dataset.tmp_drug_strength
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_drug_strength
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_drug_strength
 ;
 
 -- ------------------------------------------------------------------------------
 -- concept_class
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.concept_class AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.concept_class AS
 SELECT
     *,
     'concept_class' AS load_table_id,
     0 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_concept_class
+    @bq_target_project.@bq_target_dataset.tmp_concept_class
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_concept_class
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_concept_class
 ;
 
 -- ------------------------------------------------------------------------------
 -- concept_ancestor
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.concept_ancestor AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.concept_ancestor AS
 SELECT
     *,
     'concept_ancestor' AS load_table_id,
     0 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_concept_ancestor
+    @bq_target_project.@bq_target_dataset.tmp_concept_ancestor
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_concept_ancestor
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_concept_ancestor
 ;
 
 -- ------------------------------------------------------------------------------
 -- concept_synonym
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.concept_synonym AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.concept_synonym AS
 SELECT
     *,
     'concept_synonym' AS load_table_id,
     0 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_concept_synonym
+    @bq_target_project.@bq_target_dataset.tmp_concept_synonym
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_concept_synonym
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_concept_synonym
 ;
 
 -- ------------------------------------------------------------------------------
 -- domain
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.domain AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.domain AS
 SELECT
     *,
     'domain' AS load_table_id,
     0 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_domain
+    @bq_target_project.@bq_target_dataset.tmp_domain
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_domain
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_domain
 ;
 
 -- ------------------------------------------------------------------------------
 -- relationship
 -- ------------------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@bq_target_project.@bq_target_dataset`.relationship AS
+CREATE OR REPLACE TABLE @bq_target_project.@bq_target_dataset.relationship AS
 SELECT
     *,
     'relationship' AS load_table_id,
     0 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_relationship
+    @bq_target_project.@bq_target_dataset.tmp_relationship
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_relationship
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_relationship
 ;
 

--- a/vocabulary_refresh/custom_concept_stats.sql
+++ b/vocabulary_refresh/custom_concept_stats.sql
@@ -12,7 +12,7 @@ SELECT
   min(concept_id) AS min_concept_id, 
   max(concept_id) AS max_concept_id, 
   count(*) AS row_count
-FROM `bq_target_project.bq_target_dataset.concept` 
+FROM @bq_target_project.@bq_target_dataset.concept
 WHERE concept_id >= 2000000000
 GROUP BY vocabulary_id 
 ORDER BY vocabulary_id 

--- a/vocabulary_refresh/custom_vocabularies.sql
+++ b/vocabulary_refresh/custom_vocabularies.sql
@@ -26,14 +26,14 @@
 -- go
 
 -- -- temp create backup
--- CREATE TABLE `@bq_target_project.@bq_target_dataset`.concept_bak AS
--- SELECT * FROM `@bq_target_project.@bq_target_dataset`.concept
+-- CREATE TABLE @bq_target_project.@bq_target_dataset.concept_bak AS
+-- SELECT * FROM @bq_target_project.@bq_target_dataset.concept
 -- ;
--- CREATE TABLE `@bq_target_project.@bq_target_dataset`.concept_relationship_bak AS
--- SELECT * FROM `@bq_target_project.@bq_target_dataset`.concept_relationship
+-- CREATE TABLE @bq_target_project.@bq_target_dataset.concept_relationship_bak AS
+-- SELECT * FROM @bq_target_project.@bq_target_dataset.concept_relationship
 -- ;
--- CREATE TABLE `@bq_target_project.@bq_target_dataset`.vocabulary_bak AS
--- SELECT * FROM `@bq_target_project.@bq_target_dataset`.vocabulary
+-- CREATE TABLE @bq_target_project.@bq_target_dataset.vocabulary_bak AS
+-- SELECT * FROM @bq_target_project.@bq_target_dataset.vocabulary
 -- ;
 
 
@@ -44,9 +44,9 @@
 
 -- tmp_custom_concept
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_concept;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_concept;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.tmp_custom_concept AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.tmp_custom_concept AS
 SELECT
     voc.source_concept_id           AS concept_id,
     voc.concept_name                AS concept_name,
@@ -67,7 +67,7 @@ SELECT
     -- voc.load_table_id               AS load_table_id,
     -- MIN(voc.load_row_id)            AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping voc
+    @bq_target_project.@bq_target_dataset.tmp_custom_mapping voc
 GROUP BY
     voc.source_concept_id,
     voc.concept_name,
@@ -87,9 +87,9 @@ GROUP BY
 
 -- tmp_custom_concept_relationship
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_concept_relationship;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_concept_relationship;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.tmp_custom_concept_relationship AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.tmp_custom_concept_relationship AS
 SELECT
     tcr.source_concept_id               AS concept_id_1,
     CASE
@@ -106,7 +106,7 @@ SELECT
     -- tcr.load_table_id                   AS load_table_id,
     -- tcr.load_row_id                     AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping tcr
+    @bq_target_project.@bq_target_dataset.tmp_custom_mapping tcr
 WHERE
     tcr.target_concept_id IS NOT NULL
 
@@ -128,16 +128,16 @@ SELECT
     -- tcr.load_table_id                   AS load_table_id,
     -- tcr.load_row_id                     AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping tcr
+    @bq_target_project.@bq_target_dataset.tmp_custom_mapping tcr
 WHERE
     tcr.target_concept_id IS NOT NULL
 ;
 
 -- tmp_custom_vocabulary
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary_dist;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary_dist;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary_dist AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary_dist AS
 SELECT
     voc.source_vocabulary_id        AS source_vocabulary_id,
 
@@ -146,15 +146,15 @@ SELECT
     -- voc.load_table_id               AS load_table_id,
     -- MIN(voc.load_row_id)            AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_mapping voc
+    @bq_target_project.@bq_target_dataset.tmp_custom_mapping voc
 GROUP BY
     voc.source_vocabulary_id
     -- voc.load_table_id
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary AS
 SELECT
     voc.source_vocabulary_id        AS vocabulary_id,
     voc.source_vocabulary_id        AS vocabulary_name,
@@ -168,22 +168,22 @@ SELECT
     voc.load_table_id               AS load_table_id,
     voc.load_row_id                 AS load_row_id
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary_dist voc
+    @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary_dist voc
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary_dist;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary_dist;
 
 -- -------------------------------------------------------------------
 -- Re-write voc_concept to remove previous version of custom concept
 -- Keep PEDSnet originated custom concepts
 -- -------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_concept;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_concept;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.tmp_voc_concept AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.tmp_voc_concept AS
 SELECT *
 FROM
-    `@bq_target_project.@bq_target_dataset`.concept
+    @bq_target_project.@bq_target_dataset.concept
 WHERE
     concept_id < 2000000000
 ;
@@ -193,17 +193,17 @@ WHERE
 -- Keep links to PEDSnet originated custom concepts
 -- ----------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_concept_relationship;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_concept_relationship;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.tmp_voc_concept_relationship AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.tmp_voc_concept_relationship AS
 SELECT vr.*
 FROM
-    `@bq_target_project.@bq_target_dataset`.concept_relationship vr
+    @bq_target_project.@bq_target_dataset.concept_relationship vr
 INNER JOIN
-    `@bq_target_project.@bq_target_dataset`.tmp_voc_concept vc1
+    @bq_target_project.@bq_target_dataset.tmp_voc_concept vc1
         ON  vc1.concept_id = vr.concept_id_1
 INNER JOIN
-    `@bq_target_project.@bq_target_dataset`.tmp_voc_concept vc2
+    @bq_target_project.@bq_target_dataset.tmp_voc_concept vc2
         ON  vc2.concept_id = vr.concept_id_2
 ;
 
@@ -211,7 +211,7 @@ INNER JOIN
 -- Add new custom concepts to the re-written
 -- -------------------------------------------------------------------
 
-INSERT INTO `@bq_target_project.@bq_target_dataset`.tmp_voc_concept
+INSERT INTO @bq_target_project.@bq_target_dataset.tmp_voc_concept
 SELECT
     voc.concept_id              AS concept_id,
     voc.concept_name            AS concept_name,
@@ -228,25 +228,25 @@ SELECT
     -- voc.load_row_id              AS load_row_id
     -- when loaded not by vocabulary_refresh, raw concept tables have no load_row_id, so comment it temporarily
 FROM 
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_concept voc
+    @bq_target_project.@bq_target_dataset.tmp_custom_concept voc
 -- LEFT JOIN
---     `@bq_target_project.@bq_target_dataset`.concept vc
+--     @bq_target_project.@bq_target_dataset.concept vc
 --         ON  vc.concept_id = voc.concept_id
 -- WHERE
 --     vc.concept_id IS NULL
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.concept;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.concept;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.concept AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.concept AS
 SELECT * 
-FROM `@bq_target_project.@bq_target_dataset`.tmp_voc_concept;
+FROM @bq_target_project.@bq_target_dataset.tmp_voc_concept;
 
 -- ----------------------------------------------------------------------
 -- Add relationships to the added custom concepts
 -- ----------------------------------------------------------------------
 
-INSERT INTO `@bq_target_project.@bq_target_dataset`.tmp_voc_concept_relationship
+INSERT INTO @bq_target_project.@bq_target_dataset.tmp_voc_concept_relationship
 SELECT
     tcr.concept_id_1             AS concept_id_1,
     tcr.concept_id_2             AS concept_id_2,
@@ -258,31 +258,31 @@ SELECT
     -- tcr.load_table_id            AS load_table_id,
     -- tcr.load_row_id              AS load_row_id
 FROM 
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_concept_relationship tcr
+    @bq_target_project.@bq_target_dataset.tmp_custom_concept_relationship tcr
 -- LEFT JOIN 
---     `@bq_target_project.@bq_target_dataset`.concept_relationship vcr
+--     @bq_target_project.@bq_target_dataset.concept_relationship vcr
 --         ON  tcr.concept_id_1 = vcr.concept_id_1
 --         AND tcr.concept_id_2 = vcr.concept_id_2
 -- WHERE
 --     vcr.concept_id_1 IS NULL
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.concept_relationship;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.concept_relationship;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.concept_relationship AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.concept_relationship AS
 SELECT *
-FROM `@bq_target_project.@bq_target_dataset`.tmp_voc_concept_relationship;
+FROM @bq_target_project.@bq_target_dataset.tmp_voc_concept_relationship;
 
 -- ----------------------------------------------------------------------
 -- Re-write vocabularies to remove previous version of custom vocabularies
 -- ----------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_vocabulary;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_vocabulary;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.tmp_voc_vocabulary AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.tmp_voc_vocabulary AS
 SELECT *
 FROM
-    `@bq_target_project.@bq_target_dataset`.vocabulary
+    @bq_target_project.@bq_target_dataset.vocabulary
 WHERE
     vocabulary_concept_id < 2000000000
 ;
@@ -291,7 +291,7 @@ WHERE
 -- Add custom vocabularies to Vocabulary and Concept table
 -- ----------------------------------------------------------------------
 
-INSERT INTO `@bq_target_project.@bq_target_dataset`.tmp_voc_vocabulary
+INSERT INTO @bq_target_project.@bq_target_dataset.tmp_voc_vocabulary
 SELECT
     voc.vocabulary_id         AS vocabulary_id,
     voc.vocabulary_name       AS vocabulary_name,
@@ -302,16 +302,16 @@ SELECT
     -- voc.load_table_id           AS load_table_id,
     -- voc.load_row_id             AS load_row_id
 FROM 
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary voc
+    @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary voc
 ;
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.vocabulary;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.vocabulary;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.vocabulary AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.vocabulary AS
 SELECT *
-FROM `@bq_target_project.@bq_target_dataset`.tmp_voc_vocabulary;
+FROM @bq_target_project.@bq_target_dataset.tmp_voc_vocabulary;
 
-INSERT INTO `@bq_target_project.@bq_target_dataset`.concept
+INSERT INTO @bq_target_project.@bq_target_dataset.concept
 SELECT
     vcv.vocabulary_concept_id   AS concept_id,
     vcv.vocabulary_name         AS concept_name,
@@ -327,7 +327,7 @@ SELECT
     -- NULL                        AS load_table_id,
     -- NULL                        AS load_row_id
 FROM 
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary vcv 
+    @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary vcv 
 ;
 
 
@@ -337,15 +337,15 @@ FROM
 -- tmp_custom_concept_skipped
 -- -------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_concept_skipped;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_concept_skipped;
 
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.tmp_custom_concept_skipped AS
+CREATE TABLE @bq_target_project.@bq_target_dataset.tmp_custom_concept_skipped AS
 SELECT
     tcc.*
 FROM
-    `@bq_target_project.@bq_target_dataset`.tmp_custom_concept tcc
+    @bq_target_project.@bq_target_dataset.tmp_custom_concept tcc
 INNER JOIN
-    `@bq_target_project.@bq_target_dataset`.concept vc
+    @bq_target_project.@bq_target_dataset.concept vc
         ON  tcc.concept_id = vc.concept_id
         AND tcc.concept_name <> vc.concept_name
 ;
@@ -354,10 +354,10 @@ INNER JOIN
 -- clean up
 -- -------------------------------------------------------------------
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_concept;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_concept_relationship;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_concept;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_concept_relationship;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_vocabulary;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_concept;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_concept_relationship;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_concept;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_concept_relationship;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_vocabulary;
 

--- a/vocabulary_refresh/vocabulary_check_bq.sql
+++ b/vocabulary_refresh/vocabulary_check_bq.sql
@@ -12,15 +12,15 @@
 -- -------------------------------------------------------------------
 
 --relationships cycle
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_1;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_1
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_1;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_1
 AS
 SELECT
     1 check_id,
     'relationships cycle' AS check_name,
     r.*
-FROM `@bq_target_project.@bq_target_dataset`.concept_relationship r,
-    `@bq_target_project.@bq_target_dataset`.concept_relationship r_int
+FROM @bq_target_project.@bq_target_dataset.concept_relationship r,
+    @bq_target_project.@bq_target_dataset.concept_relationship r_int
 WHERE r.invalid_reason IS NULL
     AND r_int.concept_id_1 = r.concept_id_2
     AND r_int.concept_id_2 = r.concept_id_1
@@ -30,16 +30,16 @@ WHERE r.invalid_reason IS NULL
 ;
 
 --opposing relationships between same pair of concepts
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_2;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_2
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_2;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_2
 AS
 SELECT 
     2 check_id,
     'opposing relationships between same pair of concepts' AS check_name,
     r.*
-FROM `@bq_target_project.@bq_target_dataset`.concept_relationship r,
-    `@bq_target_project.@bq_target_dataset`.concept_relationship r_int,
-    `@bq_target_project.@bq_target_dataset`.relationship rel
+FROM @bq_target_project.@bq_target_dataset.concept_relationship r,
+    @bq_target_project.@bq_target_dataset.concept_relationship r_int,
+    @bq_target_project.@bq_target_dataset.relationship rel
 WHERE r.invalid_reason IS NULL
     AND r.relationship_id = rel.relationship_id
     AND r_int.concept_id_1 = r.concept_id_1
@@ -50,19 +50,19 @@ WHERE r.invalid_reason IS NULL
 ;
 
 --relationships without reverse
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_3;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_3
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_3;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_3
 AS
 SELECT 
     3 check_id,
     'relationships without reverse' AS check_name,
     r.*
-FROM `@bq_target_project.@bq_target_dataset`.concept_relationship r,
-    `@bq_target_project.@bq_target_dataset`.relationship rel
+FROM @bq_target_project.@bq_target_dataset.concept_relationship r,
+    @bq_target_project.@bq_target_dataset.relationship rel
 WHERE r.relationship_id = rel.relationship_id
     AND NOT EXISTS (
         SELECT 1
-        FROM `@bq_target_project.@bq_target_dataset`.concept_relationship r_int
+        FROM @bq_target_project.@bq_target_dataset.concept_relationship r_int
         WHERE r_int.relationship_id = rel.reverse_relationship_id
             AND r_int.concept_id_1 = r.concept_id_2
             AND r_int.concept_id_2 = r.concept_id_1
@@ -75,16 +75,16 @@ WHERE r.relationship_id = rel.relationship_id
 
 
 --direct and reverse mappings are not same
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_6;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_6
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_6;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_6
 AS
 SELECT 
     6 check_id,
     'direct and reverse mappings are not same' AS check_name,
     r.*
-FROM `@bq_target_project.@bq_target_dataset`.concept_relationship r,
-    `@bq_target_project.@bq_target_dataset`.relationship rel,
-    `@bq_target_project.@bq_target_dataset`.concept_relationship r_int
+FROM @bq_target_project.@bq_target_dataset.concept_relationship r,
+    @bq_target_project.@bq_target_dataset.relationship rel,
+    @bq_target_project.@bq_target_dataset.concept_relationship r_int
 WHERE r.relationship_id = rel.relationship_id
     AND r_int.relationship_id = rel.reverse_relationship_id
     AND r_int.concept_id_1 = r.concept_id_2
@@ -97,8 +97,8 @@ WHERE r.relationship_id = rel.relationship_id
 
 
 --wrong valid_start_date, valid_end_date or invalid_reason for the concept
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_7;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_7
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_7;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_7
 AS
 SELECT 
     7 check_id,
@@ -109,7 +109,7 @@ SELECT
     c.valid_start_date,
     c.valid_end_date,
     c.invalid_reason
-FROM `@bq_target_project.@bq_target_dataset`.concept c
+FROM @bq_target_project.@bq_target_dataset.concept c
 -- JOIN vocabulary_conversion vc ON vc.vocabulary_id_v5 = c.vocabulary_id
 -- table vocabulary_conversion is absent FROM a usual vocab package
 WHERE (
@@ -133,8 +133,8 @@ WHERE (
 ;
 
 --wrong valid_start_date, valid_end_date or invalid_reason for the voc_concept_relationship
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_8;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_8
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_8;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_8
 AS
 SELECT 
     8 check_id,
@@ -161,14 +161,14 @@ FROM (
                 THEN 1
             ELSE 0
             END check_flag
-    FROM `@bq_target_project.@bq_target_dataset`.concept_relationship r
+    FROM @bq_target_project.@bq_target_dataset.concept_relationship r
     ) AS s0
 WHERE check_flag = 1
 ;
 
 --RxE to Rx name duplications
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_9;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_9
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_9;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_9
 AS
 SELECT 
     9 check_id,
@@ -179,8 +179,8 @@ SELECT
     NULL AS valid_start_date,
     NULL AS valid_end_date,
     NULL AS invalid_reason
-FROM `@bq_target_project.@bq_target_dataset`.concept c1
-JOIN `@bq_target_project.@bq_target_dataset`.concept c2 ON upper(c2.concept_name) = upper(c1.concept_name)
+FROM @bq_target_project.@bq_target_dataset.concept c1
+JOIN @bq_target_project.@bq_target_dataset.concept c2 ON upper(c2.concept_name) = upper(c1.concept_name)
     AND c2.concept_class_id = c1.concept_class_id
     AND c2.vocabulary_id = 'RxNorm Extension'
     AND c2.invalid_reason IS NULL
@@ -189,19 +189,19 @@ WHERE c1.vocabulary_id = 'RxNorm'
 ;
 
 --one concept has multiple replaces
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_10;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_10
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_10;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_10
 AS
 SELECT 
     10 check_id,
     'one concept has multiple replaces' AS check_name,
     r.*
-FROM `@bq_target_project.@bq_target_dataset`.concept_relationship r
+FROM @bq_target_project.@bq_target_dataset.concept_relationship r
 INNER JOIN
     (
         SELECT r_int.concept_id_1,
             r_int.relationship_id
-        FROM `@bq_target_project.@bq_target_dataset`.concept_relationship r_int
+        FROM @bq_target_project.@bq_target_dataset.concept_relationship r_int
         WHERE r_int.relationship_id IN (
                 'Concept replaced by',
                 'Concept same_as to',
@@ -220,8 +220,8 @@ INNER JOIN
 ;
 
 --wrong concept_name [AVOF-1438]
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_11;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_11
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_11;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_11
 AS
 SELECT 
     11 check_id,
@@ -232,21 +232,21 @@ SELECT
     c.valid_start_date,
     c.valid_end_date,
     c.invalid_reason
-FROM `@bq_target_project.@bq_target_dataset`.concept c
+FROM @bq_target_project.@bq_target_dataset.concept c
 WHERE c.domain_id <> 'Metadata'
     AND c.concept_code = 'OMOP generated'
 ;
 
 --wrong relationships: 'Maps to'/'Maps to value' not to 'S'
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_12;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_12
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_12;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_12
 AS
 SELECT 
     12 check_id,
     'wrong relationships: "Maps to"/"Maps to value" not to "S"' AS check_name,
     r.*
-FROM `@bq_target_project.@bq_target_dataset`.concept c2,
-    `@bq_target_project.@bq_target_dataset`.concept_relationship r
+FROM @bq_target_project.@bq_target_dataset.concept c2,
+    @bq_target_project.@bq_target_dataset.concept_relationship r
 WHERE c2.concept_id = r.concept_id_2
     AND coalesce(c2.standard_concept,'C')<>'S'
     AND r.relationship_id IN ('Maps to','Maps to value')
@@ -254,15 +254,15 @@ WHERE c2.concept_id = r.concept_id_2
 ;
 
 --wrong relationships: 'Maps to'/'Maps to value' not FROM 'C' or NULL (unless it is to self)
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_13;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_13
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_13;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_13
 AS
 SELECT 
     13 check_id,
     'wrong relationships: "Maps to"/"Maps to value" not FROM "C" or NULL (unless it is to self)' AS check_name,
     r.*
-FROM `@bq_target_project.@bq_target_dataset`.concept c1,
-    `@bq_target_project.@bq_target_dataset`.concept_relationship r
+FROM @bq_target_project.@bq_target_dataset.concept c1,
+    @bq_target_project.@bq_target_dataset.concept_relationship r
 WHERE c1.concept_id = r.concept_id_1
     AND coalesce(c1.standard_concept,'C')='S'
     AND r.relationship_id IN ('Maps to','Maps to value')
@@ -271,8 +271,8 @@ WHERE c1.concept_id = r.concept_id_1
 ;
 
 --nonexistent relationships, classes, domains and vocabularies
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_14;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_14
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_14;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_14
 AS
 SELECT 
     14 check_id,
@@ -280,13 +280,13 @@ SELECT
     relationship_id 
 FROM
 (
-    SELECT relationship_id FROM `@bq_target_project.@bq_target_dataset`.concept_relationship
+    SELECT relationship_id FROM @bq_target_project.@bq_target_dataset.concept_relationship
     EXCEPT DISTINCT
-    SELECT relationship_id FROM `@bq_target_project.@bq_target_dataset`.relationship
+    SELECT relationship_id FROM @bq_target_project.@bq_target_dataset.relationship
 );
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_15;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_15
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_15;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_15
 AS
 SELECT 
     15 check_id,
@@ -294,13 +294,13 @@ SELECT
     concept_class_id
 FROM
 (
-    SELECT concept_class_id FROM `@bq_target_project.@bq_target_dataset`.concept
+    SELECT concept_class_id FROM @bq_target_project.@bq_target_dataset.concept
     EXCEPT DISTINCT
-    SELECT concept_class_id FROM `@bq_target_project.@bq_target_dataset`.concept_class
+    SELECT concept_class_id FROM @bq_target_project.@bq_target_dataset.concept_class
 );
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_16;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_16
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_16;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_16
 AS
 SELECT 
     16 check_id,
@@ -308,13 +308,13 @@ SELECT
     domain_id
 FROM
 (
-    SELECT domain_id FROM `@bq_target_project.@bq_target_dataset`.concept
+    SELECT domain_id FROM @bq_target_project.@bq_target_dataset.concept
     EXCEPT DISTINCT
-    SELECT domain_id FROM `@bq_target_project.@bq_target_dataset`.domain
+    SELECT domain_id FROM @bq_target_project.@bq_target_dataset.domain
 );
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_17;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_17
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_17;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_17
 AS
 SELECT 
     17 check_id,
@@ -322,62 +322,62 @@ SELECT
     vocabulary_id
 FROM
 (
-    SELECT vocabulary_id FROM `@bq_target_project.@bq_target_dataset`.concept
+    SELECT vocabulary_id FROM @bq_target_project.@bq_target_dataset.concept
     EXCEPT DISTINCT
-    SELECT vocabulary_id FROM `@bq_target_project.@bq_target_dataset`.vocabulary
+    SELECT vocabulary_id FROM @bq_target_project.@bq_target_dataset.vocabulary
 );
 
 -- create and show summary
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_errors_summary;
-CREATE TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_errors_summary
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_errors_summary;
+CREATE TABLE @bq_target_project.@bq_target_dataset.z_check_voc_errors_summary
 AS
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_1
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_1
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_2
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_2
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_3
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_3
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_6
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_6
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_7
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_7
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_8
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_8
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_9
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_9
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_10
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_10
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_11
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_11
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_12
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_12
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_13
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_13
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_14
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_14
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_15
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_15
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_16
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_16
     GROUP BY check_id, check_name
 UNION ALL
-SELECT check_id, check_name, COUNT(*) AS row_count FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_17
+SELECT check_id, check_name, COUNT(*) AS row_count FROM @bq_target_project.@bq_target_dataset.z_check_voc_17
     GROUP BY check_id, check_name
 ;
 
-SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_errors_summary
+SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_errors_summary
 ORDER BY check_id;
 

--- a/vocabulary_refresh/vocabulary_cleanup_bq.sql
+++ b/vocabulary_refresh/vocabulary_cleanup_bq.sql
@@ -11,28 +11,28 @@
 -- -------------------------------------------------------------------
 
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_1;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_2;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_3;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_6;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_7;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_8;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_9;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_10;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_11;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_12;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_13;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_14;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_15;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_16;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_17;
--- DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.z_check_voc_errors_summary;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_1;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_2;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_3;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_6;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_7;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_8;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_9;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_10;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_11;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_12;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_13;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_14;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_15;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_16;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_17;
+-- DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.z_check_voc_errors_summary;
 
 
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_concept;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_concept_relationship;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_custom_vocabulary;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_concept;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_concept_relationship;
-DROP TABLE IF EXISTS `@bq_target_project.@bq_target_dataset`.tmp_voc_vocabulary;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_concept;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_concept_relationship;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_custom_vocabulary;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_concept;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_concept_relationship;
+DROP TABLE IF EXISTS @bq_target_project.@bq_target_dataset.tmp_voc_vocabulary;
 

--- a/vocabulary_refresh/vocabulary_cleanup_bq_m.sql
+++ b/vocabulary_refresh/vocabulary_cleanup_bq_m.sql
@@ -10,98 +10,98 @@
 -- -------------------------------------------------------------------
 
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_1)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_1)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_1;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_1;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_2)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_2)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_2;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_2;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_3)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_3)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_3;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_3;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_5)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_5)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_5;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_5;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_6)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_6)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_6;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_6;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_7)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_7)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_7;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_7;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_8)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_8)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_8;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_8;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_9)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_9)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_9;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_9;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_10)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_10)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_10;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_10;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_11)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_11)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_11;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_11;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_12)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_12)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_12;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_12;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_13)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_13)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_13;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_13;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_14)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_14)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_14;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_14;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_15)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_15)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_15;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_15;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_16)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_16)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_16;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_16;
 END IF
 ;
 
-IF NOT EXISTS (SELECT * FROM `@bq_target_project.@bq_target_dataset`.z_check_voc_17)
+IF NOT EXISTS (SELECT * FROM @bq_target_project.@bq_target_dataset.z_check_voc_17)
 THEN
-    DROP TABLE `@bq_target_project.@bq_target_dataset`.z_check_voc_17;
+    DROP TABLE @bq_target_project.@bq_target_dataset.z_check_voc_17;
 END IF
 ;

--- a/z_more/tmp_src_d_micro.sql
+++ b/z_more/tmp_src_d_micro.sql
@@ -3,7 +3,7 @@
 -- MIMIC IV 2.0: generate src_d_micro from microbiologyevents
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE TABLE `@etl_project`.@etl_dataset.tmp_src_d_micro AS
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.tmp_src_d_micro AS
 WITH d_micro AS (
 
     SELECT DISTINCT
@@ -16,7 +16,7 @@ WITH d_micro AS (
             ab_itemid AS itemid
         ))                                  AS trace_id
     FROM
-        `@source_project`.@hosp_dataset.microbiologyevents
+        @source_project.@hosp_dataset.microbiologyevents
     WHERE
         ab_itemid IS NOT NULL
     UNION ALL
@@ -30,7 +30,7 @@ WITH d_micro AS (
             test_itemid AS itemid
         ))                                  AS trace_id
     FROM
-        `@source_project`.@hosp_dataset.microbiologyevents
+        @source_project.@hosp_dataset.microbiologyevents
     WHERE
         test_itemid IS NOT NULL
     UNION ALL
@@ -44,7 +44,7 @@ WITH d_micro AS (
             org_itemid AS itemid
         ))                                  AS trace_id
     FROM
-        `@source_project`.@hosp_dataset.microbiologyevents
+        @source_project.@hosp_dataset.microbiologyevents
     WHERE
         org_itemid IS NOT NULL
     UNION ALL
@@ -58,7 +58,7 @@ WITH d_micro AS (
             spec_itemid AS itemid
         ))                                  AS trace_id
     FROM
-        `@source_project`.@hosp_dataset.microbiologyevents
+        @source_project.@hosp_dataset.microbiologyevents
     WHERE
         spec_itemid IS NOT NULL
 )
@@ -73,4 +73,3 @@ SELECT
 FROM
     d_micro
 ;
-


### PR DESCRIPTION
In many places in this code, backticks were used around project and dataset parameters but not around the table name. A parameter is of the form `@<identifier>`. This can lead to syntax errors  :
```
Formatting query...
CREATE OR REPLACE TABLE `lcp-internal.mimiciv_chorus_tmp`.concept AS
.
.
.
Syntax error: Unexpected "." at [1:25]
```
These backticks are not necessary, so this PR removes them in all cases where they where used around parameters. 