### PR TITLE
Tighten filter to prevent events before birth

### DIFF
--- a/etl/etl/lk_procedure.sql
+++ b/etl/etl/lk_procedure.sql
@@ -114,6 +114,8 @@ WHERE
 -- Rule 4, d_items custom mapping
 -- gcpt_datetimeevents_to_concept -> mimiciv_proc_datetimeevents
 -- filter out 55 rows where the year is earlier than one year before patient's birth
+-- updating this to filter out all rows where the year is earlier than the patient's birth in OMOP, which is equal to
+-- anchor_year
 -- -------------------------------------------------------------------
 INSERT INTO `@etl_project`.@etl_dataset.lk_proc_d_items_clean
 SELECT
@@ -133,7 +135,7 @@ INNER JOIN
     `@etl_project`.@etl_dataset.src_patients pat
         ON  pat.subject_id = src.subject_id
 WHERE
-    EXTRACT(YEAR FROM src.value) >= pat.anchor_year - pat.anchor_age - 1
+    EXTRACT(YEAR FROM src.value) >= pat.anchor_year
 ;
 
 


### PR DESCRIPTION
There was already some custom code to filter out rows where an event would occur before a patient's birth (which is taken as their `anchor_year`). That formula had a buffer (`pat.anchor_age - 1`) which was still allowing some events which were before a patient's birth year to make it through the build. Since it shouldn't be possible to have an event before a birth year, I've tightened the formula to only allow events in or after the patient's birth year. 