### PR TITLE
Update cdm_person.sql

### DIFF
--- a/etl/etl/cdm_person.sql
+++ b/etl/etl/cdm_person.sql
@@ -109,7 +109,7 @@ SELECT
         WHEN p.gender = 'M' THEN 8507 -- MALE
         ELSE 0 
     END                             AS gender_concept_id,
-    p.anchor_year                   AS year_of_birth,
+    p.anchor_year-p.anchor_age      AS year_of_birth,
     CAST(NULL AS INT64)             AS month_of_birth,
     CAST(NULL AS INT64)             AS day_of_birth,
     CAST(NULL AS DATETIME)          AS birth_datetime,


### PR DESCRIPTION
According to MIMICIV-3.1 description, "the anchor_age provides the patient age in the given anchor_year", so the patients' year_of_birth should be "p.anchor_year-p.anchor_age" instead of "p.anchor_year"