### PR TITLE
Update person table per new _delta vocabulary approach

### DIFF
--- a/etl/etl/cdm_person.sql
+++ b/etl/etl/cdm_person.sql
@@ -95,7 +95,7 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_person
 
 INSERT INTO @etl_project.@etl_dataset.cdm_person
 SELECT
-    FARM_FINGERPRINT(CAST(p.subject_id AS STRING)) AS person_id,
+    `@etl_project.@etl_dataset`.obf_id(p.subject_id) AS person_id,
     CASE 
         WHEN p.gender = 'F' THEN 8532 -- FEMALE
         WHEN p.gender = 'M' THEN 8507 -- MALE

--- a/etl/etl/cdm_person.sql
+++ b/etl/etl/cdm_person.sql
@@ -89,7 +89,7 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_person
 
 INSERT INTO @etl_project.@etl_dataset.cdm_person
 SELECT
-    `@etl_project.@etl_dataset`.obf_id(p.subject_id) AS person_id,
+    `@etl_project.@etl_dataset`.obf_id(p.subject_id, 32) AS person_id,
     CASE 
         WHEN p.gender = 'F' THEN 8532 -- FEMALE
         WHEN p.gender = 'M' THEN 8507 -- MALE

--- a/etl/etl/cdm_person.sql
+++ b/etl/etl/cdm_person.sql
@@ -9,12 +9,6 @@
 -- Dependencies: run after st_core.sql
 -- -------------------------------------------------------------------
 
--- -------------------------------------------------------------------
--- Known issues / Open points:
---
--- negative unique id from FARM_FINGERPRINT()
---
--- -------------------------------------------------------------------
 
 -- -------------------------------------------------------------------
 -- tmp_subject_race
@@ -125,10 +119,30 @@ SELECT
     CAST(p.subject_id AS STRING)    AS person_source_value,
     p.gender                        AS gender_source_value,
     0                               AS gender_source_concept_id,
-    rc.race_first                   AS race_source_value,
-    map_rc.source_concept_id        AS race_source_concept_id,
-    CAST(NULL AS STRING)            AS ethnicity_source_value,
-    CAST(NULL AS INT64)             AS ethnicity_source_concept_id,
+    COALESCE(
+        CASE
+            WHEN map_rc.domain_id = 'Race'
+                THEN map_rc.source_code
+            ELSE NULL
+    END, CAST(NULL AS STRING))      AS race_source_value,
+    COALESCE(
+        CASE
+            WHEN map_rc.domain_id = 'Race'
+                THEN map_rc.source_concept_id
+            ELSE NULL
+    END, 0)                         AS race_source_concept_id,
+    COALESCE(
+        CASE
+            WHEN map_rc.domain_id = 'Ethnicity' THEN map_rc.source_code
+            WHEN map_rc.domain_id = 'Race' AND map_rc.source_code LIKE '%HISPANIC/LATINO%' THEN map_rc.source_code
+            ELSE NULL
+        END, CAST(NULL AS STRING))  AS ethnicity_source_value,
+    COALESCE(
+    CASE
+        WHEN map_rc.domain_id = 'Ethnicity' THEN map_rc.source_concept_id
+        WHEN map_rc.domain_id = 'Race' AND map_rc.source_code LIKE '%HISPANIC/LATINO%' THEN map_rc.source_concept_id
+        ELSE NULL
+    END, 0)                         AS ethnicity_source_concept_id,
     --
     'person.patients'               AS unit_id,
     p.load_table_id                 AS load_table_id,

--- a/etl/etl/cdm_person.sql
+++ b/etl/etl/cdm_person.sql
@@ -118,7 +118,7 @@ SELECT
             WHEN map_rc.domain_id = 'Ethnicity' THEN map_rc.target_concept_id
             WHEN map_rc.domain_id = 'Race' AND map_rc.source_code LIKE '%HISPANIC/LATINO%' THEN 38003563
             ELSE NULL
-        END, 38003564)              AS ethnicity_concept_id,
+        END, 0)                     AS ethnicity_concept_id,
     CAST(NULL AS INT64)             AS location_id,
     CAST(NULL AS INT64)             AS provider_id,
     CAST(NULL AS INT64)             AS care_site_id,


### PR DESCRIPTION
The primary purpose of this PR is to update the build of the person table to make use of the updated vocabulary approach from #37. 

This first requires changes to the build of `lk_pat_race_concept`:
- From the vocabulary, use `concept_name` instead of `concept_code` to match to the patients race. Since the race column in MIMIC is based on a string not a code this seems more appropriate. 
- Add a filter of `concept_class_id` on `mimic-race` to limit to the MIMIC race concepts.

Next, when building the person table I've made the following notable changes:
- Set `ethnicity_source_value` and `ethnicity_source_concept_id` to `NULL` since MIMIC only provides this information under race
- Set `race_concept_id` with the concept for the MIMIC race category except when the race is "HISPANIC OR LATINO". In this case `race_concept_id` is set to zero. 
- Set `ethnicity_concept_id` to the `target_concept_id` when the `domain_id` in the vocabulary is 'Ethnicity'. This currently only applies to races of "HISPANIC OR LATINO" which maps to Concept ID 38003563. MIMIC also has a number of race entries which contain the phrase "HISPANIC/LATINO" followed by more specific region information. In those cases we also map to 38003563. I keep the mapping of these two statements separate (even though they map to the same concept_id) for clarity. 

Another update creates the `person_id` in a deterministic manner instead of creating it based on `GENERATE_UUID()` which is random. This will allow for consistency with subsequent builds. 