### PR TITLE
Push to `main` warning

### DIFF
--- a/.github/workflows/warn-on-main-pr.yml
+++ b/.github/workflows/warn-on-main-pr.yml
@@ -1,0 +1,18 @@
+name: Warn if PR opened against main
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  warn:
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ⚠️ **Warning:** This PR targets the `main` branch.
+            Please ensure this is intentional. Current development on `main` has been paused. 
+            A major update is being worked on against the `dev` branch and will be merged into
+            `main` once ready.


### PR DESCRIPTION
Currently the active development on this repository is being done against the `dev` branch. Once those changes are finalized, we will merge `dev` into main. 

This PR adds a workflow to warn users against opening PRs against `main`. This is primarily to prevent those of us who are doing the active development against `dev` from mistakenly merging our changes into `main`. 

If you notice an issue in `main` that needs to be fixed soon, you can still open a PR against `main` and we will merge the update into `dev` as well, if needed. 