### PR TITLE
Use subprocess for BigQuery queries (fix backtick handling)

### DIFF
--- a/scripts/bq_run_script.py
+++ b/scripts/bq_run_script.py
@@ -7,6 +7,7 @@ import sys
 import getopt
 import json
 import datetime
+import subprocess
 
 # ----------------------------------------------------
 # default config values
@@ -233,7 +234,7 @@ def main():
             print('No such file or directory: {file}\n'.format(file=s_filename))
 
     else:
-        bq_command = "bq query --use_legacy_sql=false \"{query}\""
+        bq_base_cmd = ["bq", "query", "--use_legacy_sql=false"]
         s_done = []
         s_done.append(nice_message('start...', 0, ''))
 
@@ -247,13 +248,19 @@ def main():
             query_no = 0
             for s_query in s_queries:
 
-                bqc = bq_command.format(
-                    query=troubleshooting_bqc_format(format_query(s_query, config))
-                )
+                formatted_query = troubleshooting_bqc_format(format_query(s_query, config))
+                cmd = bq_base_cmd + [formatted_query]
                 query_no += 1
                 print('Starting query...')
-
-                rc = os.system(bqc)
+                try:
+                    completed = subprocess.run(cmd, capture_output=True, text=True)
+                    rc = completed.returncode
+                    if rc != 0:
+                        print('bq stdout:\n' + completed.stdout)
+                        print('bq stderr:\n' + completed.stderr)
+                except FileNotFoundError:
+                    rc = 127
+                    print('Error: bq CLI not found in PATH')
 
                 if rc != 0:
                     break


### PR DESCRIPTION
This PR updates BigQuery command execution to use `subprocess.run` with an argument list, rather than `os.system` and shell quoting. This change prevents the shell from interpreting backticks as command substitution, which previously caused issues when running queries with backticked identifiers. In POSIX shells, backticks are always executed unless inside single quotes, so passing the SQL directly as an argument avoids this problem entirely.

As discussed in #33, BigQuery allows unquoted hyphens in project IDs for most statements (`SELECT, CREATE TABLE, JOIN,` etc.) because the grammar treats the first segment as a `project_id`. However, not all statements make this assumption (e.g., `CREATE FUNCTION, CALL`), and in those cases, a hyphen can be misinterpreted as a subtraction operator unless the identifier is quoted. This update ensures that queries are passed to BigQuery exactly as written, so backticks can be used where required by BigQuery itself, without shell interference.