### PR TITLE
Add mixing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ python vocabulary_refresh.py -s20
 python vocabulary_refresh.py -s30
 cd ../
 python scripts/wf_read.py -e conf/<env>.etlconf
+python scripts/run_workflow.py -e conf/<env>.etlconf -c conf/workflow_setup.conf
 python scripts/run_workflow.py -e conf/<env>.etlconf -c conf/workflow_ddl.conf
 python scripts/run_workflow.py -e conf/<env>.etlconf -c conf/workflow_staging.conf
 python scripts/run_workflow.py -e conf/<env>.etlconf -c conf/workflow_etl.conf

--- a/conf/full.etlconf
+++ b/conf/full.etlconf
@@ -22,12 +22,26 @@
         "@atlas_project": "odysseus-mimic-dev",
         "@atlas_dataset": "mimiciv_full_current_cdm_*",
 
-        "@waveforms_csv_path":  "gs://bucket..."
+        "@waveforms_csv_path":  "gs://bucket...",
+
+        "@obf_c": "2654435761",            
+        "@obf_o": "1013904223",            
+        "@obf_function_name": "obf_id",    
+        "@obf_enable": "true",             
+        "@obf_comment": "Deterministic 32-bit permutation: (x * @obf_c + @obf_o) mod 2^32; C odd, O any."
 
     },
 
     "workflows":
     [
+        
+        {
+            "workflow": "setup",
+            "comment": "setup code needed to run the etl",
+            "type": "sql",
+            "conf": "workflow_setup.conf"
+        },
+
         {
             "workflow": "ddl",
             "comment": "use the same dataset templates as in etl section",

--- a/conf/full.etlconf
+++ b/conf/full.etlconf
@@ -25,10 +25,12 @@
         "@waveforms_csv_path":  "gs://bucket...",
 
         "@obf_c": "2654435761",            
-        "@obf_o": "1013904223",            
+        "@obf_o": "1013904223",
+        "@obf64_c": "1073741827",
+        "@obf64_o": "847261935",
         "@obf_function_name": "obf_id",    
         "@obf_enable": "true",             
-        "@obf_comment": "Deterministic 32-bit permutation: (x * @obf_c + @obf_o) mod 2^32; C odd, O any."
+        "@obf_comment": "Deterministic permutation: 32-bit (x * @obf_c + @obf_o) mod 2^32; 64-bit (x * @obf64_c + @obf64_o) mod 2^64; C values odd, O values any."
 
     },
 

--- a/conf/workflow_setup.conf
+++ b/conf/workflow_setup.conf
@@ -1,0 +1,10 @@
+{
+    "workflow": "setup",
+    "comment": "setup code needed to run the etl",
+    "type": "sql",
+
+    "scripts": 
+    [
+        {"script": "etl/setup/udf_obfuscation.sql",      "comment": ""}
+    ]
+}

--- a/etl/setup/udf_obfuscation.sql
+++ b/etl/setup/udf_obfuscation.sql
@@ -2,16 +2,36 @@
 -- Obfuscation UDF
 -- Uses global constants from configuration: @obf_c, @obf_o, @obf64_c, @obf64_o
 -- Deterministic permutation over 32-bit or 64-bit unsigned space:
---   32-bit: y = (x * C + O) mod 2^32, implemented via masking with 0xFFFFFFFF
---   64-bit: y = (x * C + O) mod 2^64
--- NOTE: Input assumed non-negative INT64. User must specify bit width (32 or 64).
+--   For integers: y = (x * C + O) mod 2^32/2^64
+--   For strings: y = (FARM_FINGERPRINT(x) * C + O) mod 2^32/2^64
+--   32-bit: implemented via masking with 0xFFFFFFFF
+--   64-bit: full 64-bit range
+-- NOTE: Two functions provided:
+--       obf_id(x INT64, bits INT64) - for integer inputs
+--       obf_id_str(x STRING, bits INT64) - for string inputs
+--       Strings are first converted to hash via FARM_FINGERPRINT, then obfuscated.
 -- -------------------------------------------------------------------
 
+-- Integer version of obf_id
 CREATE OR REPLACE FUNCTION `@etl_project.@etl_dataset.obf_id`(x INT64, bits INT64)
 RETURNS INT64 AS (
   CASE 
-    WHEN bits = 32 THEN ((x * CAST(@obf_c AS INT64) + CAST(@obf_o AS INT64)) & 0xFFFFFFFF)
-    WHEN bits = 64 THEN (x * CAST(@obf64_c AS INT64) + CAST(@obf64_o AS INT64))
+    WHEN bits = 32 THEN 
+      CAST((CAST(x AS BIGNUMERIC) * CAST(@obf_c AS BIGNUMERIC) + CAST(@obf_o AS BIGNUMERIC)) AS INT64) & 0xFFFFFFFF
+    WHEN bits = 64 THEN 
+      CAST(MOD(CAST(x AS BIGNUMERIC) * CAST(@obf64_c AS BIGNUMERIC) + CAST(@obf64_o AS BIGNUMERIC), CAST(9223372036854775807 AS BIGNUMERIC)) AS INT64)
+    ELSE ERROR('Unsupported bit width')
+  END
+);
+
+-- String version of obf_id
+CREATE OR REPLACE FUNCTION `@etl_project.@etl_dataset.obf_id_str`(x STRING, bits INT64)
+RETURNS INT64 AS (
+  CASE 
+    WHEN bits = 32 THEN 
+      CAST((CAST(FARM_FINGERPRINT(x) & 0x7FFFFFFF AS BIGNUMERIC) * CAST(@obf_c AS BIGNUMERIC) + CAST(@obf_o AS BIGNUMERIC)) AS INT64) & 0xFFFFFFFF
+    WHEN bits = 64 THEN 
+      CAST(MOD(CAST(FARM_FINGERPRINT(x) & 0x7FFFFFFFFFFFFFFF AS BIGNUMERIC) * CAST(@obf64_c AS BIGNUMERIC) + CAST(@obf64_o AS BIGNUMERIC), CAST(9223372036854775807 AS BIGNUMERIC)) AS INT64)
     ELSE ERROR('Unsupported bit width')
   END
 );

--- a/etl/setup/udf_obfuscation.sql
+++ b/etl/setup/udf_obfuscation.sql
@@ -1,13 +1,17 @@
 -- -------------------------------------------------------------------
 -- Obfuscation UDF
--- Uses global constants from configuration: @obf_c, @obf_o
--- Deterministic permutation over 32-bit unsigned space:
---   y = (x * C + O) mod 2^32
--- Implemented via masking with 0xFFFFFFFF.
--- NOTE: Input assumed non-negative INT64 fitting in 32 bits.
+-- Uses global constants from configuration: @obf_c, @obf_o, @obf64_c, @obf64_o
+-- Deterministic permutation over 32-bit or 64-bit unsigned space:
+--   32-bit: y = (x * C + O) mod 2^32, implemented via masking with 0xFFFFFFFF
+--   64-bit: y = (x * C + O) mod 2^64
+-- NOTE: Input assumed non-negative INT64. User must specify bit width (32 or 64).
 -- -------------------------------------------------------------------
 
-CREATE OR REPLACE FUNCTION `@etl_project.@etl_dataset`.obf_id(x INT64)
+CREATE OR REPLACE FUNCTION `@etl_project.@etl_dataset.obf_id`(x INT64, bits INT64)
 RETURNS INT64 AS (
-  ((x * CAST(@obf_c AS INT64) + CAST(@obf_o AS INT64)) & 0xFFFFFFFF)
+  CASE 
+    WHEN bits = 32 THEN ((x * CAST(@obf_c AS INT64) + CAST(@obf_o AS INT64)) & 0xFFFFFFFF)
+    WHEN bits = 64 THEN (x * CAST(@obf64_c AS INT64) + CAST(@obf64_o AS INT64))
+    ELSE ERROR('Unsupported bit width')
+  END
 );

--- a/etl/setup/udf_obfuscation.sql
+++ b/etl/setup/udf_obfuscation.sql
@@ -1,0 +1,13 @@
+-- -------------------------------------------------------------------
+-- Obfuscation UDF
+-- Uses global constants from configuration: @obf_c, @obf_o
+-- Deterministic permutation over 32-bit unsigned space:
+--   y = (x * C + O) mod 2^32
+-- Implemented via masking with 0xFFFFFFFF.
+-- NOTE: Input assumed non-negative INT64 fitting in 32 bits.
+-- -------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION `@etl_project.@etl_dataset`.obf_id(x INT64)
+RETURNS INT64 AS (
+  ((x * CAST(@obf_c AS INT64) + CAST(@obf_o AS INT64)) & 0xFFFFFFFF)
+);


### PR DESCRIPTION
This PR adds code to create a mixing function as part of the setup step in the workflow. The new `obf_id` function produces:
- Deterministic outputs
- Positive, 32-bit integer values
- Reversible mappings

The goal is to use this in place of `FARM_FINGERPRINT`, which produces a signed 64-bit integer. In OMOP, we prefer unsigned 32-bit integers for IDs when possible. The reversibility of `obf_id` is not a concern, as it operates on already de-identified data. The goal is to generate unique, transformed (not anonymized or confidential) values for OMOP IDs.