### PR TITLE
Update procedure filter to align with updated birth year

### DIFF
--- a/etl/etl/lk_procedure.sql
+++ b/etl/etl/lk_procedure.sql
@@ -135,7 +135,7 @@ INNER JOIN
     @etl_project.@etl_dataset.src_patients pat
         ON  pat.subject_id = src.subject_id
 WHERE
-    EXTRACT(YEAR FROM src.value) >= pat.anchor_year
+    EXTRACT(YEAR FROM src.value) >= pat.anchor_year - pat.anchor_year
 ;
 
 

--- a/etl/etl/lk_procedure.sql
+++ b/etl/etl/lk_procedure.sql
@@ -135,7 +135,7 @@ INNER JOIN
     @etl_project.@etl_dataset.src_patients pat
         ON  pat.subject_id = src.subject_id
 WHERE
-    EXTRACT(YEAR FROM src.value) >= pat.anchor_year - pat.anchor_year
+    EXTRACT(YEAR FROM src.value) >= pat.anchor_year - pat.anchor_age
 ;
 
 


### PR DESCRIPTION
In #34 we adjusted the filter which only allows values where the year is `>=` the patient's birth year. The birth year was taken as `anchor_year` from MIMIC. 

Using `anchor_year` as `person.year_of_birth` isn't ideal and was properly updated in #42. Given that `year_of_birth` is now set as `anchor_year` - `anchor_age`, we need to essentially revert #34. However, I don't think we need to subtract 1 additional year as the original code had (`>= pat.anchor_year - pat.anchor_age - 1`). For example, if a patient was born in 1980 and was 1 year old at the time, we should allow results with years `>= 1979`. Using `>= pat.anchor_year - pat.anchor_age - 1` would give 1978, which isn't correct.   