### PR TITLE
Correct cohort schema

### DIFF
--- a/etl/ddl/ddl_cdm_5_4_2.sql
+++ b/etl/ddl/ddl_cdm_5_4_2.sql
@@ -543,3 +543,26 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cdm_source
   vocabulary_version              STRING    not null
 )
 ;
+
+
+--HINT DISTRIBUTE_ON_KEY(subject_id)
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cohort
+(
+  cohort_definition_id  INT64     not null ,
+  subject_id            INT64     not null ,
+  cohort_start_date     DATE      not null ,
+  cohort_end_date       DATE      not null
+)
+;
+
+
+CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cohort_definition (
+  cohort_definition_id            INT64       not null,
+  cohort_definition_name          STRING      not null,
+  cohort_definition_description   STRING              ,
+  definition_type_concept_id      INT64       not null,
+  cohort_definition_syntax        STRING              ,
+  subject_concept_id              INT64       not null,
+  cohort_initiation_date          DATE
+)
+;

--- a/etl/ddl/ddl_voc_5_4_2.sql
+++ b/etl/ddl/ddl_voc_5_4_2.sql
@@ -109,13 +109,3 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.voc_drug_strength (
   invalid_reason              STRING
 )
 ;
-
-
-CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_cohort
-(
-  cohort_definition_id  INT64     not null ,
-  subject_id            INT64     not null ,
-  cohort_start_date     DATE      not null ,
-  cohort_end_date       DATE      not null
-)
-;


### PR DESCRIPTION
In #40 , we updated the DDL schema from 5.3.1 to 5.4.2. However, there were two issues:

- The cohort table was added under `ddl_voc` when it should be under `ddl_cdm`
- The cohort_definition table was missing

This PR resolves both of those issues. 