### PR TITLE
Update ETL to v5.4.2

### DIFF
--- a/etl/etl/cdm_device_exposure.sql
+++ b/etl/etl/cdm_device_exposure.sql
@@ -36,12 +36,16 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_device_exposure
     device_exposure_end_datetime    DATETIME             ,
     device_type_concept_id          INT64       not null ,
     unique_device_id                STRING               ,
+    production_id                   STRING               ,
     quantity                        INT64                ,
     provider_id                     INT64                ,
     visit_occurrence_id             INT64                ,
     visit_detail_id                 INT64                ,
     device_source_value             STRING               ,
     device_source_concept_id        INT64                ,
+    unit_concept_id                 INT64                ,
+    unit_source_value               STRING               ,
+    unit_source_concept_id          INT64                ,
     -- 
     unit_id                       STRING,
     load_table_id                 STRING,
@@ -62,6 +66,7 @@ SELECT
     src.end_datetime                            AS device_exposure_end_datetime,
     src.type_concept_id                         AS device_type_concept_id,
     CAST(NULL AS STRING)                        AS unique_device_id,
+    CAST(NULL AS STRING)                        AS production_id,
     CAST(
         IF(ROUND(src.quantity) = src.quantity, src.quantity, NULL)
         AS INT64)                               AS quantity,
@@ -70,6 +75,9 @@ SELECT
     CAST(NULL AS INT64)                         AS visit_detail_id,
     src.source_code                             AS device_source_value,
     src.source_concept_id                       AS device_source_concept_id,
+    CAST(NULL AS INT64)                         AS unit_concept_id,
+    CAST(NULL AS STRING)                        AS unit_source_value,
+    CAST(NULL AS INT64)                         AS unit_source_concept_id
     -- 
     CONCAT('device.', src.unit_id)  AS unit_id,
     src.load_table_id               AS load_table_id,

--- a/etl/etl/cdm_location.sql
+++ b/etl/etl/cdm_location.sql
@@ -31,6 +31,10 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_location
     zip                   STRING             ,
     county                STRING             ,
     location_source_value STRING             ,
+    country_concept_id    INT64              ,
+    country_source_value  STRING             ,
+    latitude              FLOAT64            ,
+    longitude             FLOAT64            ,
     -- 
     unit_id                       STRING,
     load_table_id                 STRING,
@@ -49,6 +53,10 @@ SELECT
     CAST(NULL AS STRING)        AS zip,
     CAST(NULL AS STRING)        AS county,
     'Beth Israel Hospital'      AS location_source_value,
+    '4330442'                   AS country_concept_id,
+    'United States of America'  AS country_source_value,
+    '42.33979'                  AS latitude,
+    '-71.10488'                 AS longitude,
     -- 
     'location.null'             AS unit_id,
     'null'                      AS load_table_id,

--- a/etl/etl/cdm_measurement.sql
+++ b/etl/etl/cdm_measurement.sql
@@ -51,6 +51,8 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_measurement
     measurement_source_concept_id INT64              ,
     unit_source_value             STRING             ,
     value_source_value            STRING             ,
+    measurement_event_id          INT64              ,
+    meas_event_field_concept_id   INT64              ,
     -- 
     unit_id                       STRING,
     load_table_id                 STRING,
@@ -87,6 +89,8 @@ SELECT
     src.source_concept_id                   AS measurement_source_concept_id,
     src.unit_source_value                   AS unit_source_value,
     src.value_source_value                  AS value_source_value,
+    CAST(NULL AS INT64)                     AS measurement_event_id,
+    CAST(NULL AS INT64)                     AS meas_event_field_concept_id,
     --
     CONCAT('measurement.', src.unit_id)     AS unit_id,
     src.load_table_id               AS load_table_id,

--- a/etl/etl/cdm_observation.sql
+++ b/etl/etl/cdm_observation.sql
@@ -44,6 +44,9 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_observation
     observation_source_concept_id INT64          ,
     unit_source_value             STRING         ,
     qualifier_source_value        STRING         ,
+    value_source_value            STRING         ,
+    observation_event_id          INT64          ,
+    obs_event_field_concept_id    INT64          ,
     -- 
     unit_id                       STRING,
     load_table_id                 STRING,
@@ -79,6 +82,9 @@ SELECT
     src.source_concept_id                       AS observation_source_concept_id,
     CAST(NULL AS STRING)                        AS unit_source_value,
     CAST(NULL AS STRING)                        AS qualifier_source_value,
+    CAST(NULL AS STRING)                        AS value_source_value,
+    CAST(NULL AS INT64)                         AS observation_event_id,
+    CAST(NULL AS INT64)                         AS obs_event_field_concept_id,
     -- 
     CONCAT('observation.', src.unit_id)         AS unit_id,
     src.load_table_id               AS load_table_id,

--- a/etl/etl/cdm_procedure_occurrence.sql
+++ b/etl/etl/cdm_procedure_occurrence.sql
@@ -32,6 +32,8 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_procedure_occurrence
     procedure_concept_id        INT64     not null ,
     procedure_date              DATE      not null ,
     procedure_datetime          DATETIME           ,
+    procedure_end_date          DATE               ,
+    procedure_end_datetime      DATETIME           ,
     procedure_type_concept_id   INT64     not null ,
     modifier_concept_id         INT64              ,
     quantity                    INT64              ,
@@ -61,6 +63,8 @@ SELECT
     src.target_concept_id                       AS procedure_concept_id,
     CAST(src.start_datetime AS DATE)            AS procedure_date,
     src.start_datetime                          AS procedure_datetime,
+    CAST(NULL AS DATE)                          AS procedure_end_date,
+    CAST(NULL AS DATETIME)                      AS procedure_end_datetime,
     src.type_concept_id                         AS procedure_type_concept_id,
     0                                           AS modifier_concept_id,
     CAST(src.quantity AS INT64)                 AS quantity,
@@ -79,7 +83,7 @@ FROM
     @etl_project.@etl_dataset.lk_procedure_mapped src
 INNER JOIN
     @etl_project.@etl_dataset.cdm_person per
-        ON CAST(src.subject_id AS STRING) = per.person_source_value
+        ON CAST(src.subject_id AS STRING) = per.person_s  ource_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 

--- a/etl/etl/cdm_procedure_occurrence.sql
+++ b/etl/etl/cdm_procedure_occurrence.sql
@@ -83,7 +83,7 @@ FROM
     @etl_project.@etl_dataset.lk_procedure_mapped src
 INNER JOIN
     @etl_project.@etl_dataset.cdm_person per
-        ON CAST(src.subject_id AS STRING) = per.person_s  ource_value
+        ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
         ON  vis.visit_source_value = 

--- a/etl/etl/cdm_visit_detail.sql
+++ b/etl/etl/cdm_visit_detail.sql
@@ -41,14 +41,14 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_visit_detail
     visit_detail_type_concept_id       INT64     not null , -- detail! -- this typo still exists in v.5.3.1(???)
     provider_id                        INT64              ,
     care_site_id                       INT64              ,
-    admitting_source_concept_id        INT64              ,
-    discharge_to_concept_id            INT64              ,
+    admitted_from_concept_id           INT64              ,
+    discharged_to_concept_id           INT64              ,
     preceding_visit_detail_id          INT64              ,
     visit_detail_source_value          STRING             ,
     visit_detail_source_concept_id     INT64              , -- detail! -- this typo still exists in v.5.3.1(???)
-    admitting_source_value             STRING             ,
-    discharge_to_source_value          STRING             ,
-    visit_detail_parent_id             INT64              ,
+    admitted_from_source_value         STRING             ,
+    discharged_to_source_value         STRING             ,
+    parent_visit_detail_id             INT64              ,
     visit_occurrence_id                INT64     not null ,
     -- 
     unit_id                       STRING,
@@ -83,18 +83,18 @@ SELECT
     IF(
         src.admission_location IS NOT NULL,
         COALESCE(la.target_concept_id, 0),
-        NULL)                               AS admitting_source_concept_id,
+        NULL)                               AS admitted_from_concept_id,
     IF(
         src.discharge_location IS NOT NULL,
         COALESCE(ld.target_concept_id, 0),
-        NULL)                               AS discharge_to_concept_id,
+        NULL)                               AS discharged_to_concept_id,
 
     src.preceding_visit_detail_id           AS preceding_visit_detail_id,
     src.source_value                        AS visit_detail_source_value,
     COALESCE(vdc.source_concept_id, 0)      AS visit_detail_source_concept_id,
-    src.admission_location                  AS admitting_source_value,
-    src.discharge_location                  AS discharge_to_source_value,
-    CAST(NULL AS INT64)                     AS visit_detail_parent_id,
+    src.admission_location                  AS admitted_from_source_value,
+    src.discharge_location                  AS discharged_to_source_value,
+    CAST(NULL AS INT64)                     AS parent_visit_detail_id,
     vis.visit_occurrence_id                 AS visit_occurrence_id,
     -- 
     CONCAT('visit_detail.', src.unit_id)    AS unit_id,

--- a/etl/etl/cdm_visit_occurrence.sql
+++ b/etl/etl/cdm_visit_occurrence.sql
@@ -51,10 +51,10 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_visit_occurrence
     care_site_id                  INT64              ,
     visit_source_value            STRING             ,
     visit_source_concept_id       INT64              ,
-    admitting_source_concept_id   INT64              ,
-    admitting_source_value        STRING             ,
-    discharge_to_concept_id       INT64              ,
-    discharge_to_source_value     STRING             ,
+    admitted_from_concept_id      INT64              ,
+    admitted_from_source_value    STRING             ,
+    discharged_to_concept_id      INT64              ,
+    discharged_to_source_value    STRING             ,
     preceding_visit_occurrence_id INT64              ,
     -- 
     unit_id                       STRING,
@@ -81,13 +81,13 @@ SELECT
     IF(
         src.admission_location IS NOT NULL,
         COALESCE(la.target_concept_id, 0),
-        NULL)                               AS admitting_source_concept_id,
-    src.admission_location                  AS admitting_source_value,
+        NULL)                               AS admitted_from_concept_id,
+    src.admission_location                  AS admitted_from_source_value,
     IF(
         src.discharge_location IS NOT NULL,
         COALESCE(ld.target_concept_id, 0),
-        NULL)                               AS discharge_to_concept_id,
-    src.discharge_location                  AS discharge_to_source_value,
+        NULL)                               AS discharged_to_concept_id,
+    src.discharge_location                  AS discharged_to_source_value,
     LAG(src.visit_occurrence_id) OVER ( 
         PARTITION BY subject_id, hadm_id 
         ORDER BY start_datetime


### PR DESCRIPTION
In #40, we updated the DDL to Common Data Model (CDM) v5.4.2. This PR updates the ETL scripts to comply with CDM v5.4.2. 

In two cases (`visit_occurrence`, `visit_detail`) some of the variable names were updated. In most cases, new variables were added to a given table. In this scenario, I generally added the variables and assigned NULL to the new value. Updates to add meaningful values to the new variables will be handled in separate PRs on a table by table basis. Here is a summary of the variables that were added and how they were updated/handled in this PR:

- table: `device_exposure`
  - variables: `production_id`, `unit_concept_id`, `unit_source_value`, `unit_source_concept_id`
  - updated: set as NULL. See #55 for details.
- table: `location`
  - variables: `country_concept_id`, `country_source_value`, `latitude`, `longitude`
  - updated: in this case the variables were updated with meaningful values. Since this seemed straight-forward and didn't require extensive changes, I went ahead and implemented it as part of this PR. 
- table: `measurement`
  - variables: `measurement_event_id`, `meas_event_field_concept_id`
  - updated: set as NULL
- table: `observation`
  - variables: `value_source_value`, `observation_event_id`, `obs_event_field_concept_id`
  - updated: set as NULL
- table: `procedure_occurrence`
  - variables: `procedure_end_date`, `procedure_end_datetime`
  - updated: set as NULL. In this case I don't think the corresponding "start" variables are being set properly. See #54 for details.  

There are some tables in v5.4.2 which aren't being built as part of the ETL. Adding the code to build these tables will also be handled in a separate PR. 
  
