### PR TITLE
Use `hadm_id` for `visit_source_value`

### DIFF
--- a/etl/etl/cdm_visit_detail.sql
+++ b/etl/etl/cdm_visit_detail.sql
@@ -107,10 +107,12 @@ INNER JOIN
     @etl_project.@etl_dataset.cdm_person per 
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    @etl_project.@etl_dataset.cdm_visit_occurrence vis 
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', 
-                COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
+    @etl_project.@etl_dataset.lk_visit_clean vis 
+        ON  vis.subject_id = src.subject_id
+        AND (
+            vis.hadm_id = src.hadm_id
+            OR vis.hadm_id IS NULL AND vis.date_id = src.date_id
+        )
 LEFT JOIN
     @etl_project.@etl_dataset.cdm_care_site cs
         ON cs.care_site_source_value = src.current_location

--- a/etl/etl/lk_vis_part_2.sql
+++ b/etl/etl/lk_vis_part_2.sql
@@ -185,10 +185,7 @@ SELECT
     src.admission_type                              AS admission_type, -- current location
     src.admission_location                          AS admission_location, -- to hospital
     src.discharge_location                          AS discharge_location, -- from hospital
-    CONCAT(
-        CAST(src.subject_id AS STRING), '|',
-        CAST(src.hadm_id AS STRING)
-    )                                               AS source_value,
+    CAST(src.hadm_id AS STRING)                     AS source_value,
     -- 
     src.unit_id                     AS unit_id,
     src.load_table_id               AS load_table_id,
@@ -207,10 +204,7 @@ SELECT
     src.admission_type                              AS admission_type, -- current location
     src.admission_location                          AS admission_location, -- to hospital
     src.discharge_location                          AS discharge_location, -- from hospital
-    CONCAT(
-        CAST(src.subject_id AS STRING), '|',
-        CAST(src.date_id AS STRING)
-    )                                               AS source_value,
+    CAST(NULL AS STRING)                            AS source_value,
     -- 
     src.unit_id                     AS unit_id,
     src.load_table_id               AS load_table_id,
@@ -235,11 +229,7 @@ SELECT
     src.date_id                                     AS date_id,
     src.start_datetime                              AS start_datetime,
     src.end_datetime                                AS end_datetime,  -- if null, populate with next start_datetime
-    CONCAT(
-        CAST(src.subject_id AS STRING), '|',
-        COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)), '|',
-        CAST(src.transfer_id AS STRING)
-    )                                               AS source_value,
+    CAST(src.hadm_id AS STRING)                     AS source_value,
     src.current_location                            AS current_location, -- find prev and next for adm and disch location
     -- 
     src.unit_id                     AS unit_id,
@@ -266,10 +256,7 @@ SELECT
     CAST(src.start_datetime AS DATE)                AS date_id,
     src.start_datetime                              AS start_datetime,
     CAST(NULL AS DATETIME)                          AS end_datetime,  -- if null, populate with next start_datetime
-    CONCAT(
-        CAST(src.subject_id AS STRING), '|',
-        CAST(src.hadm_id AS STRING)
-    )                                               AS source_value,
+    CAST(src.hadm_id AS STRING)                     AS source_value,
     src.admission_type                              AS current_location, -- find prev and next for adm and disch location
     -- 
     src.unit_id                     AS unit_id,
@@ -296,11 +283,7 @@ SELECT
     CAST(src.start_datetime AS DATE)                AS date_id,
     src.start_datetime                              AS start_datetime,
     src.end_datetime                                AS end_datetime,
-    CONCAT(
-        CAST(src.subject_id AS STRING), '|',
-        CAST(src.hadm_id AS STRING), '|',
-        CAST(src.start_datetime AS STRING)
-    )                                               AS source_value,
+    CAST(src.hadm_id AS STRING)                     AS source_value,
     src.curr_service                                AS current_location,
     -- 
     src.unit_id                     AS unit_id,
@@ -327,7 +310,7 @@ SELECT
     src.date_id                                     AS date_id,
     src.start_datetime                              AS start_datetime,
     src.end_datetime                                AS end_datetime,  -- if null, populate with next start_datetime
-    src.reference_id                                AS source_value,
+    CAST(src.hadm_id AS STRING)                     AS source_value,
     src.current_location                            AS current_location, -- find prev and next for adm and disch location
     -- 
     src.unit_id                     AS unit_id,

--- a/etl/etl/lk_vis_part_2.sql
+++ b/etl/etl/lk_vis_part_2.sql
@@ -185,7 +185,7 @@ SELECT
     src.admission_type                              AS admission_type, -- current location
     src.admission_location                          AS admission_location, -- to hospital
     src.discharge_location                          AS discharge_location, -- from hospital
-    CAST(src.hadm_id AS STRING)                     AS source_value,
+    src.admission_type                              AS source_value,
     -- 
     src.unit_id                     AS unit_id,
     src.load_table_id               AS load_table_id,
@@ -204,7 +204,7 @@ SELECT
     src.admission_type                              AS admission_type, -- current location
     src.admission_location                          AS admission_location, -- to hospital
     src.discharge_location                          AS discharge_location, -- from hospital
-    CAST(NULL AS STRING)                            AS source_value,
+    src.admission_type                              AS source_value,
     -- 
     src.unit_id                     AS unit_id,
     src.load_table_id               AS load_table_id,
@@ -229,7 +229,7 @@ SELECT
     src.date_id                                     AS date_id,
     src.start_datetime                              AS start_datetime,
     src.end_datetime                                AS end_datetime,  -- if null, populate with next start_datetime
-    CAST(src.hadm_id AS STRING)                     AS source_value,
+    src.current_location                            AS source_value,
     src.current_location                            AS current_location, -- find prev and next for adm and disch location
     -- 
     src.unit_id                     AS unit_id,
@@ -256,7 +256,7 @@ SELECT
     CAST(src.start_datetime AS DATE)                AS date_id,
     src.start_datetime                              AS start_datetime,
     CAST(NULL AS DATETIME)                          AS end_datetime,  -- if null, populate with next start_datetime
-    CAST(src.hadm_id AS STRING)                     AS source_value,
+    src.admission_type                              AS source_value,
     src.admission_type                              AS current_location, -- find prev and next for adm and disch location
     -- 
     src.unit_id                     AS unit_id,
@@ -283,7 +283,7 @@ SELECT
     CAST(src.start_datetime AS DATE)                AS date_id,
     src.start_datetime                              AS start_datetime,
     src.end_datetime                                AS end_datetime,
-    CAST(src.hadm_id AS STRING)                     AS source_value,
+    src.curr_service                                AS source_value,
     src.curr_service                                AS current_location,
     -- 
     src.unit_id                     AS unit_id,
@@ -310,7 +310,7 @@ SELECT
     src.date_id                                     AS date_id,
     src.start_datetime                              AS start_datetime,
     src.end_datetime                                AS end_datetime,  -- if null, populate with next start_datetime
-    CAST(src.hadm_id AS STRING)                     AS source_value,
+    src.current_location                            AS source_value,
     src.current_location                            AS current_location, -- find prev and next for adm and disch location
     -- 
     src.unit_id                     AS unit_id,


### PR DESCRIPTION
After a discussion with @p-talapova , we agreed that it makes sense to simply use `hadm_id` for `visit_occurrence.visit_source_value`. This PR replaces the previous approach which concatenated `hadm_id` (when available) with other variables. The new approach will make joining tables via hospital admissin (`hadm_id`) cleaner and also makes it clear what `visit_source_value` represents, regardless of the source table. 