### PR TITLE
Add outputevents to measurement table build

### DIFF
--- a/conf/workflow_etl.conf
+++ b/conf/workflow_etl.conf
@@ -30,6 +30,7 @@
         {"script": "etl/etl/cdm_procedure_occurrence.sql",  "comment": "lk: condition, observation"},
 
         {"script": "etl/etl/cdm_specimen.sql",  "comment": "measurement links to speciment via fact_relationship"},
+        {"script": "etl/etl/lk_meas_outputevents.sql",        "comment": ""},
         {"script": "etl/etl/cdm_measurement.sql",       "comment": ""},
 
         {"script": "etl/etl/lk_drug.sql",               "comment": ""},

--- a/etl/etl/lk_meas_outputevents.sql
+++ b/etl/etl/lk_meas_outputevents.sql
@@ -53,11 +53,11 @@ SELECT
     src.trace_id                                                AS trace_id
 FROM
     `@etl_project`.@etl_dataset.lk_outputevents src
-LEFT JOIN `@etl_project`.@etl_dataset.concept c
+LEFT JOIN `@etl_project`.@etl_dataset.voc_concept c
     ON src.source_code = c.concept_code AND c.vocabulary_id = 'mimiciv_outputevents'
-LEFT JOIN `@etl_project`.@etl_dataset.concept_relationship cr
+LEFT JOIN `@etl_project`.@etl_dataset.voc_concept_relationship cr
     ON  c.concept_id = cr.concept_id_1
-LEFT JOIN `@etl_project`.@etl_dataset.concept c2
+LEFT JOIN `@etl_project`.@etl_dataset.voc_concept c2
     ON cr.concept_id_2 = c2.concept_id
     AND c2.standard_concept = 'S'
     AND c2.invalid_reason IS NULL


### PR DESCRIPTION
This should be merged after the PRs ahead of it.

The `lk_meas_outputevents.sql` script which can be used to add outputevent information to the measurement table was not being run by `workflow_etl.conf`. This PR adds that step to the build, see 90e5b627ea70e9fdea2a696f3ad5a0cd79f9e06a. 