### PR TITLE
Update `visit_source_value` `JOIN`s to only use `hadm_id`

### DIFF
--- a/etl/etl/cdm_condition_occurrence.sql
+++ b/etl/etl/cdm_condition_occurrence.sql
@@ -90,8 +90,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Condition'
 ;
@@ -131,8 +130,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Condition'
 ;
@@ -174,8 +172,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Condition'
 ;

--- a/etl/etl/cdm_condition_occurrence.sql
+++ b/etl/etl/cdm_condition_occurrence.sql
@@ -90,7 +90,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Condition'
 ;
@@ -130,7 +130,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Condition'
 ;
@@ -172,7 +172,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Condition'
 ;

--- a/etl/etl/cdm_device_exposure.sql
+++ b/etl/etl/cdm_device_exposure.sql
@@ -90,8 +90,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Device'
 ;
@@ -132,8 +131,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Device'
 ;

--- a/etl/etl/cdm_device_exposure.sql
+++ b/etl/etl/cdm_device_exposure.sql
@@ -90,7 +90,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Device'
 ;
@@ -131,7 +131,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Device'
 ;

--- a/etl/etl/cdm_drug_exposure.sql
+++ b/etl/etl/cdm_drug_exposure.sql
@@ -95,7 +95,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Drug'
 ;

--- a/etl/etl/cdm_drug_exposure.sql
+++ b/etl/etl/cdm_drug_exposure.sql
@@ -57,7 +57,10 @@ CREATE OR REPLACE TABLE @etl_project.@etl_dataset.cdm_drug_exposure
 
 INSERT INTO @etl_project.@etl_dataset.cdm_drug_exposure
 SELECT
-    `@etl_project.@etl_dataset`.obf_id_str(src.trace_id, 32)    AS drug_exposure_id,
+  `@etl_project.@etl_dataset`.obf_id_str(CONCAT(
+        src.trace_id, '|',
+        CAST(src.target_concept_id AS STRING)
+    ), 32)                                                      AS drug_exposure_id,
     per.person_id                                               AS person_id,
     src.target_concept_id                                       AS drug_concept_id,
     CAST(src.start_datetime AS DATE)                            AS drug_exposure_start_date,

--- a/etl/etl/cdm_drug_exposure.sql
+++ b/etl/etl/cdm_drug_exposure.sql
@@ -92,8 +92,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Drug'
 ;

--- a/etl/etl/cdm_measurement.sql
+++ b/etl/etl/cdm_measurement.sql
@@ -103,9 +103,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', 
-                COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Measurement' -- 115,272
 ;
@@ -151,8 +149,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Measurement'
 ;
@@ -198,9 +195,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', 
-                COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Measurement'
 ;
@@ -246,9 +241,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', 
-                COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Measurement'
 ;
@@ -339,6 +332,5 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value =
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 ;

--- a/etl/etl/cdm_measurement.sql
+++ b/etl/etl/cdm_measurement.sql
@@ -103,7 +103,11 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id
+        AND (
+            vis.hadm_id = src.hadm_id
+            OR vis.hadm_id IS NULL AND vis.date_id = src.date_id
+        )
 WHERE
     src.target_domain_id = 'Measurement' -- 115,272
 ;
@@ -149,7 +153,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Measurement'
 ;
@@ -195,7 +199,11 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id
+        AND (
+            vis.hadm_id = src.hadm_id
+            OR vis.hadm_id IS NULL AND vis.date_id = src.date_id
+        )
 WHERE
     src.target_domain_id = 'Measurement'
 ;
@@ -241,7 +249,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis -- 116,559
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Measurement'
 ;
@@ -332,5 +340,5 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     `@etl_project`.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 ;

--- a/etl/etl/cdm_observation.sql
+++ b/etl/etl/cdm_observation.sql
@@ -100,7 +100,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Observation'
 ;
@@ -147,7 +147,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Observation'
 ;
@@ -195,7 +195,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Observation'
 ;
@@ -240,7 +240,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Observation'
 ;
@@ -285,7 +285,12 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id
+        AND (
+            vis.hadm_id = src.hadm_id
+            OR vis.hadm_id IS NULL AND vis.date_id = src.date_id
+        )
+
 WHERE
     src.target_domain_id = 'Observation'
 ;

--- a/etl/etl/cdm_observation.sql
+++ b/etl/etl/cdm_observation.sql
@@ -100,8 +100,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Observation'
 ;
@@ -148,8 +147,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Observation'
 ;
@@ -197,8 +195,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Observation'
 ;
@@ -243,8 +240,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Observation'
 ;
@@ -289,9 +285,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', 
-                COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Observation'
 ;

--- a/etl/etl/cdm_procedure_occurrence.sql
+++ b/etl/etl/cdm_procedure_occurrence.sql
@@ -89,8 +89,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Procedure'
 ;
@@ -133,8 +132,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Procedure'
 ;
@@ -174,9 +172,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', 
-                COALESCE(CAST(src.hadm_id AS STRING), CAST(src.date_id AS STRING)))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Procedure'
 ;
@@ -217,8 +213,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = 
-            CONCAT(CAST(src.subject_id AS STRING), '|', CAST(src.hadm_id AS STRING))
+        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
 WHERE
     src.target_domain_id = 'Procedure'
 ;

--- a/etl/etl/cdm_procedure_occurrence.sql
+++ b/etl/etl/cdm_procedure_occurrence.sql
@@ -89,7 +89,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Procedure'
 ;
@@ -132,7 +132,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Procedure'
 ;
@@ -172,7 +172,11 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id
+        AND (
+            vis.hadm_id = src.hadm_id
+            OR vis.hadm_id IS NULL AND vis.date_id = src.date_id
+        )
 WHERE
     src.target_domain_id = 'Procedure'
 ;
@@ -213,7 +217,7 @@ INNER JOIN
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
     @etl_project.@etl_dataset.cdm_visit_occurrence vis
-        ON  vis.visit_source_value = CAST(src.hadm_id AS STRING)
+        ON  vis.subject_id = src.subject_id AND vis.hadm_id = src.hadm_id
 WHERE
     src.target_domain_id = 'Procedure'
 ;

--- a/etl/etl/cdm_visit_detail.sql
+++ b/etl/etl/cdm_visit_detail.sql
@@ -107,7 +107,7 @@ INNER JOIN
     @etl_project.@etl_dataset.cdm_person per 
         ON CAST(src.subject_id AS STRING) = per.person_source_value
 INNER JOIN
-    @etl_project.@etl_dataset.lk_visit_clean vis 
+    @etl_project.@etl_dataset.lk_visit_clean vis
         ON  vis.subject_id = src.subject_id
         AND (
             vis.hadm_id = src.hadm_id


### PR DESCRIPTION
This PR should be merged after the PRs ahead of it. 

In #57 , we updated `visit_source_value` to simply be `hadm_id` instead of a concatenation of `hadm_id` and other variables. This PR updates the `JOIN` statements which use `visit_source_value` to simply `JOIN` against `hadm_id`, see 225c79c7e2252377bc595ec65a0d2d994e87bb96. 